### PR TITLE
refactor: conductor → team-lead in cookbooks + references

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -6,7 +6,7 @@ Reference examples and patterns for homerun workflow phases.
 |----------|--------|---------|
 | [Discovery Dialogue](discovery-dialogue-examples.md) | discovery skill | Question patterns, validation examples |
 | [Task Decomposition](task-decomposition-examples.md) | planning skill | Decomposition patterns, sizing examples |
-| [Parallel Execution](parallel-execution-scenarios.md) | conductor skill | Concurrency scenarios, edge cases |
+| [Parallel Execution](parallel-execution-scenarios.md) | team-lead skill | Concurrency scenarios, edge cases |
 | [Review Feedback](review-feedback-examples.md) | review skill | Approval/rejection examples |
 
 **Note:** Cookbooks are NOT loaded by default - reference when detailed examples needed.

--- a/cookbooks/discovery-dialogue-examples.md
+++ b/cookbooks/discovery-dialogue-examples.md
@@ -98,17 +98,17 @@ E) Depends on the error type (let's discuss)
 
 ## Validation Dialogue Flow
 
-### Section-by-Section Confirmation
+### Document Review Confirmation
 
-After presenting each section (200-300 words):
+After presenting the complete document for review:
 
 ```
-Does this accurately capture your intent?
+Please review the complete document above. Does it accurately capture your intent?
 
 Options:
-- [Confirmed] - Move to next section
+- [Confirmed] - Looks good, proceed
 - [Minor edits] - I'll describe what to change
-- [Major revision] - Let's discuss this further
+- [Major revision] - Let's discuss specific sections further
 ```
 
 ### Handling Revisions

--- a/cookbooks/parallel-execution-scenarios.md
+++ b/cookbooks/parallel-execution-scenarios.md
@@ -1,6 +1,6 @@
 # Parallel Execution Scenarios
 
-Reference examples for conductor parallel execution patterns.
+Reference examples for team-lead parallel execution patterns.
 
 ## Concurrency Scenarios
 
@@ -8,11 +8,10 @@ Reference examples for conductor parallel execution patterns.
 
 **Config:**
 - `max_parallel_tasks: 3`
-- `max_parallel_by_model: { haiku: 5, sonnet: 3, opus: 1 }`
 
 **Current state:**
-- Running: 3 tasks (1 haiku, 2 sonnet)
-- Ready: 2 haiku tasks, 1 sonnet task
+- Running: 3 tasks
+- Ready: 2 tasks
 
 **Calculation:**
 ```
@@ -20,47 +19,39 @@ Global: 3 - 3 = 0 slots available
 Result: 0 slots (wait for completions)
 ```
 
-### Scenario 2: Model Limit Reached
+### Scenario 2: Dependency-Gated Parallelism
 
 **Config:**
 - `max_parallel_tasks: 5`
-- `max_parallel_by_model: { haiku: 5, sonnet: 3, opus: 1 }`
 
 **Current state:**
-- Running: 3 sonnet tasks
-- Ready: 2 sonnet tasks, 1 haiku task
+- Running: 3 tasks (no dependencies between them)
+- Ready: 2 tasks (both depend on running task 001)
 
 **Calculation:**
 ```
 Global: 5 - 3 = 2 slots available
-Sonnet: 3 - 3 = 0 slots (at limit)
-Haiku: 5 - 0 = 5 slots
-Result: Only haiku task can be spawned (1 slot used)
+But: ready tasks are blocked by dependency on task 001
+Result: 0 tasks can be spawned until 001 completes
 ```
 
-### Scenario 3: Mixed Model Spawning
+### Scenario 3: Mixed Readiness Spawning
 
 **Config:**
 - `max_parallel_tasks: 4`
-- `max_parallel_by_model: { haiku: 5, sonnet: 3, opus: 1 }`
 
 **Current state:**
-- Running: 1 sonnet task
-- Ready: 2 haiku, 2 sonnet, 1 opus
+- Running: 1 task
+- Ready: 3 tasks (no dependency conflicts)
 
 **Calculation:**
 ```
 Global: 4 - 1 = 3 slots available
-Haiku: 5 - 0 = 5 slots
-Sonnet: 3 - 1 = 2 slots
-Opus: 1 - 0 = 1 slot
 
-Spawn order (respecting model limits):
-1. First haiku task (3 slots -> 2)
-2. Second haiku task (2 slots -> 1)
-3. First sonnet task (1 slot -> 0)
-4. Second sonnet blocked (no global slots)
-5. Opus blocked (no global slots)
+Spawn order:
+1. First ready task (3 slots -> 2)
+2. Second ready task (2 slots -> 1)
+3. Third ready task (1 slot -> 0)
 ```
 
 ---
@@ -106,7 +97,7 @@ Task 002: Create Auth service (needs Task 001)
 003 blocked_by: [001]  <- Cycle!
 
 Result: No tasks ever become ready
-Conductor detects deadlock after 3 iterations without progress
+Team lead detects deadlock after 3 iterations without progress
 ```
 
 ### Retry Queue Priority
@@ -145,11 +136,11 @@ Effect:
 ### Task-Count Refresh
 
 ```
-conductor_refresh_interval: 5
+team_lead_refresh_interval: 5
 tasks_since_refresh: 5
 
 Trigger: tasks_since_refresh >= interval
-Action: Spawn fresh conductor, exit current
+Action: Spawn fresh team-lead session, exit current
 ```
 
 ### Token-Based Refresh

--- a/cookbooks/task-decomposition-examples.md
+++ b/cookbooks/task-decomposition-examples.md
@@ -1,6 +1,6 @@
 # Task Decomposition Examples
 
-Reference examples for decomposing tasks according to the rules in `skills/planning/SKILL.md`.
+Reference examples for decomposing tasks according to the rules in `skills/task-decomposition/SKILL.md`.
 
 ## Example 1: User Authentication Feature
 

--- a/references/context-engineering.md
+++ b/references/context-engineering.md
@@ -79,7 +79,7 @@ Skills load minimal context, with references to detailed docs:
 
 **Before (bloated):**
 ```markdown
-# Conductor Skill
+# Team Lead Skill
 
 ## Full Algorithm (500 lines of pseudocode inline)
 ...
@@ -87,10 +87,10 @@ Skills load minimal context, with references to detailed docs:
 
 **After (progressive):**
 ```markdown
-# Conductor Skill
+# Team Lead Skill
 
 ## Reference Documents
-- `references/state-machine.md` - Full algorithms
+- `references/token-estimation.md` - Token budgets and refresh triggers
 - `references/retry-patterns.md` - Retry logic details
 
 ## Summary

--- a/references/token-estimation.md
+++ b/references/token-estimation.md
@@ -15,7 +15,7 @@
 |-------|--------|---------|-----|
 | Discovery | 40K | 60K | 80K |
 | Planning | 30K | 45K | 60K |
-| Conductor | 20K | 30K | 40K |
+| Team Lead | 20K | 30K | 40K |
 | Implementer | 30K | N/A | N/A |
 | Reviewer | 30K | N/A | N/A |
 
@@ -69,8 +69,8 @@ function estimateTokens(state) {
     tasks_json: state.tasks_file ? estimateFileTokens(state.tasks_file) : 0
   };
 
-  // Conductor accumulates feedback
-  const feedbackTokens = state.parallel_state?.running_tasks
+  // Team lead accumulates feedback
+  const feedbackTokens = state.parallel_state?.active_tasks
     ?.reduce((sum, t) => sum + (t.feedback?.length || 0) * 500, 0) || 0;
 
   return base.skill_content + base.state_json + base.tasks_json + feedbackTokens;


### PR DESCRIPTION
## Summary
- Replace all "conductor" references with "team-lead" across cookbooks and reference docs (v5.4.0 rename)
- Fix stale `skills/planning/` path → `skills/task-decomposition/` (v5.1.0 rename)
- Update discovery dialogue to reflect whole-document review instead of section-by-section 200-word chunks (v5.5.0)
- Remove obsolete `max_parallel_by_model` and `conductor_refresh_interval` config keys from parallel execution scenarios
- Update `references/state-machine.md` reference to `references/token-estimation.md` (current file)

## Test plan
- [x] `grep -ri "conductor" cookbooks/ references/token-estimation.md references/context-engineering.md` returns 0 results
- [x] All 6 files preserve structure and formatting

References #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)