### PR TITLE
fix: correct quality-gates phase ordering and retry defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Start an orchestrated workflow from idea through implementation.
 |------|-------------|
 | `--auto` | Skip all confirmations — dialogue, validation, phase transitions |
 | `--resume` | Resume interrupted session |
-| `--retries N,M` | Retry limits: N=same agent, M=fresh agent (default: 2,1) |
+| `--retries N,M` | Retry limits: N=fresh agent, M=same agent (default: 1,1) |
 
 ### `/plan` — Jump to Planning
 
@@ -436,16 +436,16 @@ All inter-agent communication uses typed JSON signal envelopes. See `references/
 ## Retry Logic & Circuit Breakers
 
 ```
-Task rejected
+Task rejected (attempt 1 failed)
       │
       ▼
-  attempts < fresh_agent_limit (default: 1)
-      │ YES → Spawn fresh agent (clean slate + failure summary)
+  fresh_agent retries remaining? (default: 1)
+      │ YES → Spawn fresh agent (clean slate + structured failure summary)
       │ NO ↓
-  attempts < fresh + same_agent_limit (default: 1)
-      │ YES → Retry with same agent + accumulated context
+  same_agent retries remaining? (default: 1)
+      │ YES → Retry with same agent + targeted guidance
       │ NO ↓
-  Escalate model (sonnet → opus)
+  Model is haiku? → Escalate to sonnet
       │ NO ↓
   Escalate to user
 ```

--- a/commands/create.md
+++ b/commands/create.md
@@ -84,7 +84,7 @@ When resuming an interrupted session:
    {
      "auto_mode": false,
      "retries": {
-       "same_agent": 2,
+       "same_agent": 1,
        "fresh_agent": 1
      }
    }

--- a/references/model-routing.json
+++ b/references/model-routing.json
@@ -77,16 +77,16 @@
     "maxTurns": {
       "discovery": 30,
       "spec_review": 10,
-      "scope_analyzer": 12,
-      "task_decomposer": 10,
+      "scope_analysis": 12,
+      "task_decomposition": 10,
       "implementer": 25,
       "reviewer": 15,
-      "quality_checker": 10,
+      "quality_check": 10,
       "team_lead": 50,
-      "diagnostician": 20,
+      "diagnose": 20,
       "reverse_engineer": 30,
-      "test_skeleton_generator": 15,
-      "walkthrough_generator": 15
+      "test_skeletons": 15,
+      "walkthrough": 15
     }
   },
 
@@ -102,6 +102,7 @@
     "medium": {
       "max_implementers": 2,
       "skip_spec_review": false,
+      "skip_scope_analysis": false,
       "skip_agent_teams": false,
       "skip_separate_reviewer": false,
       "preferred_model": "sonnet"
@@ -109,6 +110,7 @@
     "large": {
       "max_implementers": 5,
       "skip_spec_review": false,
+      "skip_scope_analysis": false,
       "skip_agent_teams": false,
       "skip_separate_reviewer": false,
       "preferred_model": null

--- a/references/quality-gates.md
+++ b/references/quality-gates.md
@@ -15,9 +15,9 @@ Phase 1 ──0 errors──→ Phase 2 ──0 errors──→ Phase 3 ──0 
 
 | Phase | What | Tool | Blocking? |
 |-------|------|------|-----------|
-| **1. Lint + Format** | Code style, auto-fixable issues | Linter/formatter | Yes — fix before proceeding |
-| **2. Structure** | Unused exports, circular dependencies | Static analysis | Yes — architectural issues |
-| **3. Type Check + Build** | Type errors, compilation | TypeScript/compiler | Yes — broken code |
+| **1. Lint + Format** | Code style, auto-fixable issues | Linter/formatter (bash hook) | Yes — fix before proceeding |
+| **2. Type Check** | Type errors, compilation | TypeScript/compiler (bash hook) | Yes — broken code |
+| **3. Structure** | Unused exports, circular dependencies | LLM review | Yes — architectural issues |
 | **4. Tests** | All tests passing | Test runner | Yes — broken behavior |
 | **5. Code Recheck** | Final quality sweep | LLM review | Advisory — flag but don't block |
 
@@ -32,11 +32,12 @@ Phase 1 ──0 errors──→ Phase 2 ──0 errors──→ Phase 3 ──0 
 
 Phases 1-2 run via bash hooks at zero LLM cost:
 - `homerun-quality-lint.sh` → Phase 1
-- `homerun-quality-typecheck.sh` → Phase 3
+- `homerun-quality-typecheck.sh` → Phase 2
 
-Phases 4-5 require LLM turns:
+Phases 3-5 require LLM turns or test runner:
+- Phase 3: Structural review of implementation quality (LLM)
 - Phase 4: Run test suite, analyze failures
-- Phase 5: Structural review of implementation quality
+- Phase 5: Final code recheck (LLM)
 
 ## Statuses
 

--- a/references/state-schema.md
+++ b/references/state-schema.md
@@ -56,7 +56,7 @@ The `state.json` file lives at the worktree root and tracks the entire `/create`
     "max_identical_rejections": 3,
     "max_iterations_without_progress": 3,
     "retries": {
-      "same_agent": 2,
+      "same_agent": 1,
       "fresh_agent": 1
     }
   },


### PR DESCRIPTION
## Summary
- Fix `quality-gates.md` phase ordering: Types (Phase 2) before Structure (Phase 3)
- Reconcile retry defaults to `same_agent: 1` across state-schema, model-routing.json, create.md
- Fix `model-routing.json` naming consistency between phase_models and agent_limits
- Add `skip_scope_analysis` to medium/large scale routing
- Fix README retry flowchart to match retry-patterns.md

References #5

## Test plan
- [x] `python3 -c "import json; json.load(open('references/model-routing.json'))"` — valid JSON
- [x] Phase ordering matches quality-check skill and hook implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)