### PR TITLE
fix: replace conductor with team-lead in diagrams

### DIFF
--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -7,38 +7,39 @@ Visual documentation of the homerun workflow system.
 | Diagram | Purpose | Key Visualizations |
 |---------|---------|-------------------|
 | [sequence-diagram.md](sequence-diagram.md) | Message flow between agents | Full workflow, retry flow, parallel execution |
-| [phase-flowchart.md](phase-flowchart.md) | Decision logic within each phase | Discovery dialogue, planning decomposition, conductor loop, TDD flow, reviewer verification |
+| [phase-flowchart.md](phase-flowchart.md) | Decision logic within each phase | Discovery dialogue, planning decomposition, team-lead loop, TDD flow, reviewer verification |
 | [architecture.md](architecture.md) | Component and service relationships | System overview, agent spawning, file system, model routing, concurrency |
 | [context-flow.md](context-flow.md) | Token budgets and agent spawning | Per-phase budgets, observation masking, spec extraction, file read strategy |
-| [state-machine.md](state-machine.md) | Phase and task state transitions | Workflow phases, task status, retry logic, circuit breaker, conductor loop, dialogue states |
+| [state-machine.md](state-machine.md) | Phase and task state transitions | Workflow phases, task status, retry logic, circuit breaker, team-lead loop, dialogue states |
 
 ## Quick Reference
 
 ### Agent Model Assignment
 ```
-Discovery   → opus (user dialogue, requirements)
-Spec Review → sonnet (spec consistency validation)
-Planning    → opus (high-leverage decomposition)
-Team Lead   → sonnet (coordination, teammate scaling)
-Conductor   → haiku (mechanical scheduling — fallback)
-Implementer → haiku/sonnet (based on task_type)
-Reviewer    → sonnet (quality judgment)
+Discovery        → inherit (user dialogue, requirements)
+Spec Review      → sonnet (spec consistency validation)
+Scope Analyzer   → sonnet (scope extraction, AC validation)
+Task Decomposer  → opus (high-leverage decomposition)
+Team Lead        → inherit (inline skill, coordination)
+Implementer      → sonnet/haiku (based on task_type)
+Reviewer         → sonnet (quality judgment)
+Quality Checker  → sonnet (final verification)
 ```
 
 ### Context Budgets
 ```
 Discovery:   10-20K tokens (grows during dialogue)
 Planning:    ~10K tokens (specs + state)
-Conductor:   ~5K tokens (refreshes every 5 tasks)
+Team Lead:   ~5K tokens (inline skill, refreshes every 5 tasks)
 Implementer: <20K tokens target (with masking)
 Reviewer:    ~10K tokens
 ```
 
 ### Key State Transitions
 ```
-Phases: discovery → spec_review → planning → implementing → completing → done
+Phases: discovery → spec_review → scope_analysis → task_decomposition → implementing → completing → done
 Tasks:  pending → in_progress → pending_review → completed/failed
-Retry:  attempt_1 → attempt_2 (same agent) → attempt_3 (fresh) → escalate
+Retry:  attempt_1 → attempt_2 (fresh agent) → attempt_3 (same agent) → escalate
 ```
 
 ## Rendering

--- a/diagrams/architecture.md
+++ b/diagrams/architecture.md
@@ -44,7 +44,8 @@ graph TB
 
     CLI --> D
     D --> SD
-    D --> SA
+    D --> SRv
+    SRv --> SA
     SA --> SSA
     SA --> TD
     TD --> STD

--- a/diagrams/context-flow.md
+++ b/diagrams/context-flow.md
@@ -42,7 +42,7 @@ graph LR
         P4[Tasks output: 2K]
     end
 
-    subgraph Conductor["Conductor (~5K)"]
+    subgraph TeamLead["Team Lead (~5K)"]
         C1[Skill: 2K]
         C2[State: 1K]
         C3[Current tasks: 1K]
@@ -67,10 +67,10 @@ graph LR
         R5[Analysis: 2K]
     end
 
-    Discovery -->|"Task(opus)"| Planning
-    Planning -->|"Task(haiku)"| Conductor
-    Conductor -->|"Task(varies)"| Implementer
-    Conductor -->|"Task(sonnet)"| Reviewer
+    Discovery -->|"Task(inherit)"| Planning
+    Planning -->|"Skill(inherit)"| TeamLead
+    TeamLead -->|"Task(varies)"| Implementer
+    TeamLead -->|"Task(sonnet)"| Reviewer
 ```
 
 ## Observation Masking Flow
@@ -154,12 +154,12 @@ sequenceDiagram
     participant M as Main (User Context)
     participant D as Discovery Context
     participant P as Planning Context
-    participant C as Conductor Context
+    participant TL as Team Lead Context
     participant I as Implementer Context
 
     Note over M: User's conversation history<br/>Could be 50K+ tokens
 
-    M->>D: Task(model: opus)
+    M->>D: Task(model: inherit)
     Note over D: Fresh context: ~2K<br/>(skill + project scan)
 
     loop Dialogue
@@ -172,21 +172,21 @@ sequenceDiagram
 
     Note over P: Fresh context: ~10K<br/>(skill + specs + state)
 
-    P->>C: Task(model: haiku)
+    P->>TL: Skill(inline, model: inherit)
     Note over P: Context discarded
 
-    Note over C: Fresh context: ~5K<br/>(skill + state + tasks)
+    Note over TL: Fresh context: ~5K<br/>(skill + state + tasks)
 
     par Parallel Spawns
-        C->>I: Task(model: haiku, background)
+        TL->>I: Task(model: varies, background)
         Note over I: Fresh: ~15K<br/>(skill + task + extracted specs)
     end
 
-    Note over C: Context grows with<br/>completion tracking
+    Note over TL: Context grows with<br/>completion tracking
 
     opt Refresh at 5 tasks
-        C->>C: Spawn fresh conductor
-        Note over C: Reset to ~5K
+        TL->>TL: Spawn fresh team-lead
+        Note over TL: Reset to ~5K
     end
 ```
 
@@ -195,7 +195,7 @@ sequenceDiagram
 ```mermaid
 xychart-beta
     title "Context Usage Per Phase"
-    x-axis ["Start", "Mid-Discovery", "End-Discovery", "Planning", "Conductor Start", "After 3 Tasks", "After 5 Tasks", "Refresh"]
+    x-axis ["Start", "Mid-Discovery", "End-Discovery", "Planning", "Team-Lead Start", "After 3 Tasks", "After 5 Tasks", "Refresh"]
     y-axis "Tokens (K)" 0 --> 50
     bar [2, 10, 18, 10, 5, 12, 18, 5]
     line [100, 100, 100, 100, 100, 100, 100, 100]

--- a/diagrams/phase-flowchart.md
+++ b/diagrams/phase-flowchart.md
@@ -22,10 +22,14 @@ flowchart TB
         D13 --> D14[Commit state.json]
     end
 
-    subgraph Phase2[Phase 2: Planning]
+    subgraph Phase2a[Phase 2a: Scope Analysis]
         P1[Read specs] --> P2[Analyze scope]
-        P2 --> P3[Create dependency graph]
-        P3 --> P4[Decompose into tasks]
+        P2 --> P2a[Extract components, validate ACs]
+        P2a --> P2b[Write scope-analysis.json]
+    end
+
+    subgraph Phase2b[Phase 2b: Task Decomposition]
+        P3[Read scope analysis] --> P4[Decompose into tasks]
         P4 --> P5{Task too big?}
         P5 -->|Yes| P6[Split into subtasks]
         P6 --> P4
@@ -39,7 +43,7 @@ flowchart TB
     end
 
     subgraph Phase3[Phase 3: Implementation]
-        C1[Conductor starts] --> C2[Read state + tasks]
+        C1[Team-lead starts] --> C2[Read state + tasks]
         C2 --> C3{All complete?}
         C3 -->|Yes| C10[WORKFLOW_COMPLETE]
         C3 -->|No| C4[Find ready tasks]
@@ -48,7 +52,7 @@ flowchart TB
         C6 --> C7[Poll for completions]
         C7 --> C8[Process reviews]
         C8 --> C9{Refresh needed?}
-        C9 -->|Yes| C11[Spawn fresh conductor]
+        C9 -->|Yes| C11[Spawn fresh team-lead]
         C9 -->|No| C2
     end
 
@@ -59,8 +63,9 @@ flowchart TB
         F2 -->|Continue| F5[Keep worktree]
     end
 
-    Phase1 --> Phase2
-    Phase2 --> Phase3
+    Phase1 --> Phase2a
+    Phase2a --> Phase2b
+    Phase2b --> Phase3
     Phase3 --> Phase4
 ```
 
@@ -149,14 +154,14 @@ flowchart TB
     Cycle -->|Yes| Fix[Reorder tasks]
     Fix --> DAG
     Cycle -->|No| Write[Write tasks.json]
-    Write --> Done[PLANNING_COMPLETE]
+    Write --> Done[TASK_DECOMPOSITION_COMPLETE]
 ```
 
-## Conductor: Main Loop
+## Team-Lead: Main Loop
 
 ```mermaid
 flowchart TB
-    Start[Start conductor] --> Read[Read state.json + tasks.json]
+    Start[Start team-lead] --> Read[Read state.json + tasks.json]
     Read --> Check{All tasks<br/>complete?}
     Check -->|Yes| Done[WORKFLOW_COMPLETE]
 
@@ -165,7 +170,7 @@ flowchart TB
     Escalate --> Choice{User choice}
     Choice -->|Retry| Unblock[Clear blocked flag]
     Choice -->|Skip| Skip[Mark skipped]
-    Choice -->|Replan| Replan[Return to planning]
+    Choice -->|Replan| Replan[Return to task decomposition]
     Unblock --> Poll
     Skip --> Poll
 
@@ -194,7 +199,7 @@ flowchart TB
 
     Spawn -->|No| Update
     Update --> Refresh{Refresh<br/>needed?}
-    Refresh -->|Yes| NewConductor[Spawn fresh conductor]
+    Refresh -->|Yes| NewTeamLead[Spawn fresh team-lead]
     Refresh -->|No| Read
 ```
 

--- a/diagrams/sequence-diagram.md
+++ b/diagrams/sequence-diagram.md
@@ -21,9 +21,9 @@ sequenceDiagram
     M->>D: Task(discovery-agent)
     activate D
 
-    loop One question at a time
-        D->>U: Question (multiple choice)
-        U->>D: Answer
+    loop 2-4 questions per message
+        D->>U: Questions (multiple choice)
+        U->>D: Answers
     end
 
     D->>FS: Write PRD.md, ADR.md, TECHNICAL_DESIGN.md
@@ -72,14 +72,14 @@ sequenceDiagram
     Note over M: Read state.json → phase: implementing
 
     Note over U,FS: Phase 4: Implementation Loop (depth 1)
-    M->>TL: Task(team-lead)
+    M->>TL: Skill(team-lead)
     activate TL
 
     loop Until all tasks complete
         TL->>FS: Read state.json, tasks.json
         TL->>TL: Find ready tasks (deps resolved)
 
-        par Parallel Implementation (depth 2)
+        par Parallel Implementation (depth 1)
             TL->>I: Task(implementer, background: true)
             activate I
             I->>FS: Read extracted spec context
@@ -89,7 +89,7 @@ sequenceDiagram
             deactivate I
         end
 
-        loop Sequential Reviews (depth 2)
+        loop Sequential Reviews (depth 1)
             TL->>R: Task(reviewer)
             activate R
             R->>FS: Read implementation + specs

--- a/diagrams/state-machine.md
+++ b/diagrams/state-machine.md
@@ -6,13 +6,19 @@
 stateDiagram-v2
     [*] --> discovery: /create
 
-    discovery --> planning: DISCOVERY_COMPLETE
+    discovery --> spec_review: DISCOVERY_COMPLETE
     discovery --> discovery: User answers question
     discovery --> discovery: Validation failed
 
-    planning --> implementing: PLANNING_COMPLETE
-    planning --> planning: DAG cycle detected
-    planning --> discovery: Major revision needed
+    spec_review --> scope_analysis: SPEC_REVIEW_COMPLETE
+    spec_review --> discovery: Major issues found
+
+    scope_analysis --> task_decomposition: SCOPE_ANALYSIS_COMPLETE
+    scope_analysis --> scope_analysis: Validation failed
+
+    task_decomposition --> implementing: PLANNING_COMPLETE
+    task_decomposition --> task_decomposition: DAG cycle detected
+    task_decomposition --> discovery: Major revision needed
 
     implementing --> implementing: Task completed
     implementing --> implementing: Task failed (low/med)
@@ -20,7 +26,7 @@ stateDiagram-v2
     implementing --> completing: All tasks done
 
     blocked --> implementing: User: retry/skip
-    blocked --> planning: User: replan
+    blocked --> task_decomposition: User: replan
 
     completing --> done: Merge/PR created
     completing --> implementing: User: continue
@@ -34,7 +40,7 @@ stateDiagram-v2
 stateDiagram-v2
     [*] --> pending: Task created
 
-    pending --> in_progress: Selected by conductor
+    pending --> in_progress: Selected by team-lead
     pending --> blocked: Dependency failed
 
     in_progress --> pending_review: Implementation complete
@@ -70,21 +76,21 @@ stateDiagram-v2
         review --> rejected: REJECTED
     }
 
-    attempt_1 --> attempt_2: same_agent retry
+    attempt_1 --> attempt_2: fresh_agent retry
     attempt_1 --> success_state: success
 
     state attempt_2 {
-        [*] --> implementing_2: With feedback
+        [*] --> implementing_2: Fresh context
         implementing_2 --> review_2
         review_2 --> success: APPROVED
         review_2 --> rejected: REJECTED
     }
 
-    attempt_2 --> attempt_3: fresh_agent retry
+    attempt_2 --> attempt_3: same_agent retry
     attempt_2 --> success_state: success
 
     state attempt_3 {
-        [*] --> implementing_3: Fresh context
+        [*] --> implementing_3: With feedback
         implementing_3 --> review_3
         review_3 --> success: APPROVED
         review_3 --> rejected: REJECTED
@@ -104,11 +110,11 @@ stateDiagram-v2
     escalation --> attempt_1: retry_with_guidance
     escalation --> success_state: mark_fixed
     escalation --> skipped_state: skip_task
-    escalation --> planning_phase: return_to_planning
+    escalation --> task_decomposition_phase: return_to_planning
 
     success_state --> [*]
     skipped_state --> [*]
-    planning_phase --> [*]
+    task_decomposition_phase --> [*]
 ```
 
 ## Circuit Breaker State Machine
@@ -128,7 +134,7 @@ stateDiagram-v2
     half_open --> open: Next task fails
 ```
 
-## Conductor Loop State Machine
+## Team-Lead Loop State Machine
 
 ```mermaid
 stateDiagram-v2
@@ -175,7 +181,7 @@ stateDiagram-v2
     check_refresh --> spawn_fresh: Refresh needed
     check_refresh --> read_state: Continue loop
 
-    spawn_fresh --> [*]: New conductor takes over
+    spawn_fresh --> [*]: New team-lead takes over
 
     workflow_complete --> [*]: Done
 ```
@@ -184,7 +190,7 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-    [*] --> idle: Conductor starts
+    [*] --> idle: Team-lead starts
 
     state idle {
         [*] --> finding_tasks


### PR DESCRIPTION
## Summary
- Replaced all "conductor" references with "team-lead" across 6 diagram files
- Fixed model assignments: discovery uses `inherit` (not opus), team-lead uses `inherit` (inline skill)
- Split monolithic "planning" phase into `scope_analysis` + `task_decomposition` in state machines and flowcharts
- Fixed retry order: fresh_agent first, then same_agent (per retry-patterns.md)
- Fixed sequence diagram: "one question at a time" → "2-4 questions per message", Task→Skill for team-lead, depth 2→1 for implementers
- Added missing spec_review edge in architecture diagram (D→SRv→SA)

References #4

## Test plan
- [x] `grep -ri "conductor" diagrams/` returns 0 non-historical results
- [x] Mermaid syntax preserved (no structural changes to diagram format)
- [x] Phase transitions match canonical order: discovery → spec_review → scope_analysis → task_decomposition → implementing → completing → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)