### PR TITLE
fix: update eval config from homerun:planning to homerun:task-decomposition

### DIFF
--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -14,7 +14,11 @@ categories:
 
   planning:
     description: Tests for planning skill (task decomposition, DAG validation)
-    skills: [homerun:planning]
+    skills: [homerun:task-decomposition]
+
+  scope_analysis:
+    description: Tests for scope analysis skill
+    skills: [homerun:scope-analysis]
 
   implement:
     description: Tests for implementer skill (TDD, code generation)

--- a/evals/discovery/dialogue-flow.eval.yaml
+++ b/evals/discovery/dialogue-flow.eval.yaml
@@ -32,7 +32,7 @@ evaluations:
       3. Covers multiple categories (0-2): Touches on at least 2 of: purpose, users, scope, constraints, edge cases
       4. Structured approach (0-2): Questions are organized rather than random
 
-      Note: Discovery asks one question at a time. With only 5 scripted responses,
+      Note: Discovery batches 2-4 questions per message. With only 5 scripted responses,
       the dialogue may not cover all 5 categories. Score based on quality of covered categories.
 
       Score 0-10. Pass threshold: 5

--- a/evals/planning/circular-deps.eval.yaml
+++ b/evals/planning/circular-deps.eval.yaml
@@ -1,6 +1,6 @@
 name: planning-circular-deps
 description: "Verify planning detects circular task dependencies and reports them"
-workflow: homerun:planning
+workflow: homerun:task-decomposition
 tags: [planning, negative, dag, homerun]
 timeout_seconds: 300
 

--- a/evals/planning/dag-validation.eval.yaml
+++ b/evals/planning/dag-validation.eval.yaml
@@ -1,6 +1,6 @@
 name: planning-dag-validation
 description: "Verify planning produces valid DAG with no circular dependencies"
-workflow: homerun:planning
+workflow: homerun:task-decomposition
 tags: [planning, dag, homerun]
 timeout_seconds: 300
 

--- a/evals/planning/model-routing.eval.yaml
+++ b/evals/planning/model-routing.eval.yaml
@@ -1,6 +1,6 @@
 name: planning-model-routing
 description: "Verify planning assigns correct models (haiku/sonnet) to task types"
-workflow: homerun:planning
+workflow: homerun:task-decomposition
 tags: [planning, model-routing, homerun]
 timeout_seconds: 300
 

--- a/evals/planning/signal-envelope.eval.yaml
+++ b/evals/planning/signal-envelope.eval.yaml
@@ -1,6 +1,6 @@
 name: planning-signal-envelope
 description: "Verify planning emits valid PLANNING_COMPLETE signal"
-workflow: homerun:planning
+workflow: homerun:task-decomposition
 tags: [planning, signals, smoke, homerun]
 timeout_seconds: 600
 isolation: tempdir

--- a/evals/planning/task-decomposition.eval.yaml
+++ b/evals/planning/task-decomposition.eval.yaml
@@ -1,6 +1,6 @@
 name: planning-task-decomposition
 description: "Verify planning creates properly decomposed, commit-sized tasks"
-workflow: homerun:planning
+workflow: homerun:task-decomposition
 tags: [planning, decomposition, homerun]
 timeout_seconds: 600
 


### PR DESCRIPTION
## Summary
- Fix `evals/config.yaml`: rename `homerun:planning` → `homerun:task-decomposition`
- Add `scope_analysis` category to eval config
- Fix all planning eval files: `workflow: homerun:planning` → `homerun:task-decomposition`
- Update discovery dialogue eval rubric to reflect batched questions (2-4 per message)

References #5

## Test plan
- [x] `grep -r "homerun:planning" evals/` returns 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)