### PR TITLE
fix: align signal names between agents and contracts

### DIFF
--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -30,7 +30,7 @@ Follow the `homerun:implement` skill using strict TDD methodology from `homerun:
 
 **Phase:** Implementing (assigned by team-lead)
 **Input:** Single task from tasks.json + spec documents
-**Output:** `TASK_COMPLETE` (approved) or `IMPLEMENTATION_BLOCKED` signal
+**Output:** `IMPLEMENTATION_COMPLETE`, `NEEDS_REWORK`, or `IMPLEMENTATION_BLOCKED` signal
 **Next:** Review by `reviewer` agent
 
 ## TDD Cycle

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -50,7 +50,7 @@ Score the implementation 0.0-1.0 using this rubric:
 
 **Phase:** After implementation of each task
 **Input:** Completed task implementation + spec documents + task definition
-**Output:** `REVIEW_APPROVED` or `REVIEW_REJECTED` signal
+**Output:** `APPROVED` or `REJECTED` signal
 **Next:** If approved → team-lead marks task complete. If rejected → back to implementer with feedback.
 
 ## Review Checklist (Tier 2 — after hard gates pass)

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -647,7 +647,7 @@ All output MUST be valid JSON wrapped in a code block with language `json`.
   "properties": {
     "signal": { "const": "IMPLEMENTATION_BLOCKED" },
     "reason": { "type": "string" },
-    "blocker_type": { "enum": ["missing_dependency", "unclear_requirements", "technical_constraint", "test_failure", "tautological_test"] },
+    "blocker_type": { "enum": ["missing_dependency", "unclear_requirements", "technical_constraint", "test_failure", "tautological_test", "duplication_detected"] },
     "details": { "type": "array", "items": { "type": "string" } },
     "suggested_resolution": { "type": "string" }
   }


### PR DESCRIPTION
## Summary
- Fix `agents/reviewer.md`: `REVIEW_APPROVED`/`REVIEW_REJECTED` → `APPROVED`/`REJECTED`
- Fix `agents/implementer.md`: `TASK_COMPLETE` → `IMPLEMENTATION_COMPLETE`, add `NEEDS_REWORK`
- Add `duplication_detected` to `blocker_type` enum in `skills/implement/SKILL.md` and `signal-contracts.json`
- Add `NEEDS_REWORK` signal to README signal table

Closes #3

## Test plan
- [x] `grep -r "REVIEW_APPROVED\|TASK_COMPLETE" --include="*.md" --include="*.json" agents/ skills/ references/` returns 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)