### PR TITLE
fix: script hardening — DAG validator, pkg manager, sponge, scope-analyzer

### DIFF
--- a/agents/scope-analyzer.md
+++ b/agents/scope-analyzer.md
@@ -3,7 +3,7 @@ model: sonnet
 name: scope-analyzer
 color: cyan
 description: Extract scope analysis from spec documents — components, validated ACs, JIT context refs. Use after spec review passes.
-tools: Read, Grep, Glob, Bash
+tools: Read, Write, Grep, Glob, Bash
 skills: scope-analysis
 maxTurns: 12
 ---

--- a/scripts/homerun-auto-lint.sh
+++ b/scripts/homerun-auto-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: PostToolUse (matcher: Edit|Write)
 # Purpose: Auto-lint changed files after every edit
 #

--- a/scripts/homerun-post-implement.sh
+++ b/scripts/homerun-post-implement.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: SubagentStop (matcher: implementer)
 # Purpose: Log progress after an implementer finishes
 #
@@ -21,34 +21,15 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/session-state.sh"
+
 WORKTREE_PATH="${CLAUDE_WORKTREE_PATH:-$(pwd)}"
 
 # --- Session-aware state.json lookup ---
-# First: check the current worktree directly
-STATE_FILE="$WORKTREE_PATH/state.json"
+find_session_state "$WORKTREE_PATH" || true
 
-if [ ! -f "$STATE_FILE" ]; then
-  # Implementer may run in a sub-worktree. Find the parent session's state.json
-  # by matching the branch prefix (create/<session-id>).
-  BRANCH=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-  SESSION_ID="${BRANCH#create/}"
-
-  if [ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "$BRANCH" ]; then
-    # Branch is create/*, search for matching session
-    for wt in $(git -C "$WORKTREE_PATH" worktree list | awk '{print $1}'); do
-      [ "$wt" = "$WORKTREE_PATH" ] && continue
-      if [ -f "$wt/state.json" ]; then
-        FILE_SESSION_ID=$(jq -r '.session_id // empty' "$wt/state.json" 2>/dev/null)
-        if [ "$FILE_SESSION_ID" = "$SESSION_ID" ]; then
-          STATE_FILE="$wt/state.json"
-          break
-        fi
-      fi
-    done
-  fi
-fi
-
-if [ ! -f "$STATE_FILE" ]; then
+if [ -z "$STATE_FILE" ]; then
   echo "homerun-post-implement: No state.json found for this session, skipping" >&2
   exit 0
 fi
@@ -72,7 +53,6 @@ echo "homerun-post-implement: Progress — $COMPLETED/$TOTAL completed, $IN_PROG
 
 # --- Feedback pattern aggregation ---
 # Extract rejection patterns for session-level learning (non-blocking)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FEEDBACK_SCRIPT="$SCRIPT_DIR/lib/feedback-aggregator.sh"
 if [ -f "$FEEDBACK_SCRIPT" ]; then
   bash "$FEEDBACK_SCRIPT" "$(dirname "$STATE_FILE")" 2>/dev/null || true

--- a/scripts/homerun-pre-commit.sh
+++ b/scripts/homerun-pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: PreToolUse (matcher: Bash)
 # Purpose: Gate git commit/push on lint + typecheck passing
 #
@@ -23,6 +23,9 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/pkg-manager.sh"
+
 # Read hook input from stdin
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -36,19 +39,6 @@ fi
 cd "${CWD:-.}" || exit 0
 
 FAILED=()
-
-# --- Detect package manager ---
-detect_pkg_manager() {
-  if [ -f bun.lockb ] || [ -f bun.lock ]; then
-    echo "bun"
-  elif [ -f pnpm-lock.yaml ]; then
-    echo "pnpm"
-  elif [ -f yarn.lock ]; then
-    echo "yarn"
-  else
-    echo "npm"
-  fi
-}
 
 # --- Lint ---
 run_lint() {

--- a/scripts/homerun-quality-lint.sh
+++ b/scripts/homerun-quality-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: PostToolUse (or standalone)
 # Purpose: Run lint with auto-fix as standalone quality gate
 #
@@ -25,25 +25,15 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/pkg-manager.sh"
+
 # Resolve working directory
 WORKTREE_PATH="${CLAUDE_WORKTREE_PATH:-$(pwd)}"
 
 cd "$WORKTREE_PATH" || {
   echo "homerun-quality-lint: could not cd to $WORKTREE_PATH" >&2
   exit 0
-}
-
-# --- Detect package manager ---
-detect_pkg_manager() {
-  if [ -f bun.lockb ] || [ -f bun.lock ]; then
-    echo "bun"
-  elif [ -f pnpm-lock.yaml ]; then
-    echo "pnpm"
-  elif [ -f yarn.lock ]; then
-    echo "yarn"
-  else
-    echo "npm"
-  fi
 }
 
 # --- Lint with auto-fix ---

--- a/scripts/homerun-quality-typecheck.sh
+++ b/scripts/homerun-quality-typecheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: PostToolUse (or standalone)
 # Purpose: Run type checking as standalone quality gate
 #
@@ -25,25 +25,15 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/pkg-manager.sh"
+
 # Resolve working directory
 WORKTREE_PATH="${CLAUDE_WORKTREE_PATH:-$(pwd)}"
 
 cd "$WORKTREE_PATH" || {
   echo "homerun-quality-typecheck: could not cd to $WORKTREE_PATH" >&2
   exit 0
-}
-
-# --- Detect package manager ---
-detect_pkg_manager() {
-  if [ -f bun.lockb ] || [ -f bun.lock ]; then
-    echo "bun"
-  elif [ -f pnpm-lock.yaml ]; then
-    echo "pnpm"
-  elif [ -f yarn.lock ]; then
-    echo "yarn"
-  else
-    echo "npm"
-  fi
 }
 
 # --- Type check ---

--- a/scripts/homerun-task-completed.sh
+++ b/scripts/homerun-task-completed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: TaskCompleted (for Agent Teams mode)
 # Purpose: Validate implementation before marking a native task as complete
 #
@@ -21,32 +21,16 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/session-state.sh"
+source "$SCRIPT_DIR/lib/pkg-manager.sh"
+
 WORKTREE_PATH="${CLAUDE_WORKTREE_PATH:-$(pwd)}"
 
 # --- Session-aware state.json lookup ---
-# First: check the current worktree directly
-STATE_FILE="$WORKTREE_PATH/state.json"
+find_session_state "$WORKTREE_PATH" || true
 
-if [ ! -f "$STATE_FILE" ]; then
-  # Find the parent session's state.json by matching session_id
-  BRANCH=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-  SESSION_ID="${BRANCH#create/}"
-
-  if [ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "$BRANCH" ]; then
-    for wt in $(git -C "$WORKTREE_PATH" worktree list 2>/dev/null | awk '{print $1}'); do
-      [ "$wt" = "$WORKTREE_PATH" ] && continue
-      if [ -f "$wt/state.json" ]; then
-        FILE_SESSION_ID=$(jq -r '.session_id // empty' "$wt/state.json" 2>/dev/null)
-        if [ "$FILE_SESSION_ID" = "$SESSION_ID" ]; then
-          STATE_FILE="$wt/state.json"
-          break
-        fi
-      fi
-    done
-  fi
-fi
-
-if [ ! -f "$STATE_FILE" ]; then
+if [ -z "$STATE_FILE" ]; then
   # Not a homerun project, allow completion
   exit 0
 fi
@@ -59,15 +43,14 @@ if [ "$MODE" != "agent_teams" ]; then
 fi
 
 # Basic validation: check that tests pass in the worktree
-TASKS_FILE=$(jq -r '.tasks_file // "docs/tasks.json"' "$STATE_FILE")
 SOURCE_DIR=$(dirname "$STATE_FILE")
 
 # Run a quick test check (if test runner is configured)
 if [ -f "$SOURCE_DIR/package.json" ]; then
-  PKG_MANAGER=$(jq -r '.packageManager // "npm"' "$SOURCE_DIR/package.json" | cut -d@ -f1)
+  cd "$SOURCE_DIR"
+  PKG_MANAGER=$(detect_pkg_manager)
   if jq -e '.scripts.test' "$SOURCE_DIR/package.json" > /dev/null 2>&1; then
     echo "homerun-task-completed: Running tests..."
-    cd "$SOURCE_DIR"
     if ! $PKG_MANAGER test 2>&1; then
       echo "homerun-task-completed: Tests failed — blocking task completion" >&2
       exit 2  # Block completion

--- a/scripts/homerun-validate-dag.sh
+++ b/scripts/homerun-validate-dag.sh
@@ -18,7 +18,7 @@ if [[ -z "$TASKS_FILE" ]]; then
 fi
 
 if [[ ! -f "$TASKS_FILE" ]]; then
-  echo "{\"valid\":false,\"exit_code\":2,\"errors\":[\"Tasks file not found: $TASKS_FILE\"],\"warnings\":[]}" >&2
+  jq -n --arg f "$TASKS_FILE" '{"valid":false,"exit_code":2,"errors":["Tasks file not found: \($f)"],"warnings":[]}' >&2
   exit 2
 fi
 
@@ -30,7 +30,7 @@ fi
 
 # Validate JSON syntax
 if ! jq empty "$TASKS_FILE" 2>/dev/null; then
-  echo "{\"valid\":false,\"exit_code\":2,\"errors\":[\"Invalid JSON in $TASKS_FILE\"],\"warnings\":[]}" >&2
+  jq -n --arg f "$TASKS_FILE" '{"valid":false,"exit_code":2,"errors":["Invalid JSON in \($f)"],"warnings":[]}' >&2
   exit 2
 fi
 
@@ -74,13 +74,13 @@ if [[ -n "$ALL_IDS" ]]; then
     CHANGED=false
     for tid in $ALL_IDS; do
       # Skip already resolved
-      echo "$RESOLVED" | grep -qw "$tid" 2>/dev/null && continue
+      echo " $RESOLVED " | grep -qF " $tid " 2>/dev/null && continue
       # Get dependencies for this task
       DEPS=$(jq -r --arg id "$tid" '.tasks[] | select(.id == $id) | (.depends_on // [])[]' "$TASKS_FILE" 2>/dev/null || true)
       # Check if all deps are resolved
       ALL_MET=true
       for dep in $DEPS; do
-        if ! echo "$RESOLVED" | grep -qw "$dep" 2>/dev/null; then
+        if ! echo " $RESOLVED " | grep -qF " $dep " 2>/dev/null; then
           ALL_MET=false
           break
         fi
@@ -94,7 +94,7 @@ if [[ -n "$ALL_IDS" ]]; then
   # Check for unresolved tasks (involved in cycles)
   UNRESOLVED=""
   for tid in $ALL_IDS; do
-    if ! echo "$RESOLVED" | grep -qw "$tid" 2>/dev/null; then
+    if ! echo " $RESOLVED " | grep -qF " $tid " 2>/dev/null; then
       UNRESOLVED="$UNRESOLVED $tid"
     fi
   done
@@ -134,13 +134,14 @@ fi
 
 # --- 4. Dependency ordering (no task depends on higher-numbered task) ---
 DEP_ORDER_ISSUES=$(jq -r '
+  [.tasks[].id] as $all_ids |
   .tasks[] |
   .id as $tid |
-  ($tid | gsub("[^0-9]"; "")) as $tnum |
+  ($all_ids | to_entries[] | select(.value == $tid) | .key) as $tidx |
   (.depends_on // [])[] |
   . as $dep |
-  ($dep | gsub("[^0-9]"; "")) as $dnum |
-  if ($dnum | tonumber) >= ($tnum | tonumber) then
+  ($all_ids | to_entries[] | select(.value == $dep) | .key) as $didx |
+  if $didx >= $tidx then
     "Task \($tid) depends on \($dep) which comes later or is same in sequence"
   else empty end
 ' "$TASKS_FILE" 2>/dev/null || true)

--- a/scripts/homerun-worktree-setup.sh
+++ b/scripts/homerun-worktree-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook: WorktreeCreate
 # Purpose: Initialize a new homerun worktree with required structure
 #
@@ -21,6 +21,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/session-state.sh"
+
 WORKTREE_PATH="${CLAUDE_WORKTREE_PATH:-$(pwd)}"
 
 # Only run if this looks like a homerun worktree (branch starts with create/)
@@ -29,38 +32,22 @@ if [[ "$BRANCH" != create/* ]]; then
   exit 0  # Not a homerun worktree, skip
 fi
 
-# Extract the session ID from the branch name (create/<feature-slug>-<uuid>)
-# This is used to find the correct parent session's state.json
-SESSION_ID="${BRANCH#create/}"
-
-# Find state.json that belongs to THIS session (not another parallel session)
-# Match by session_id field in state.json to avoid cross-session contamination
-STATE_FILE=""
-for wt in $(git -C "$WORKTREE_PATH" worktree list | awk '{print $1}'); do
-  [ "$wt" = "$WORKTREE_PATH" ] && continue  # Skip self
-  if [ -f "$wt/state.json" ]; then
-    # Verify this state.json belongs to our session
-    FILE_SESSION_ID=$(jq -r '.session_id // empty' "$wt/state.json" 2>/dev/null)
-    if [ "$FILE_SESSION_ID" = "$SESSION_ID" ]; then
-      STATE_FILE="$wt/state.json"
-      break
-    fi
-  fi
-done
+# Find state.json that belongs to THIS session
+find_session_state "$WORKTREE_PATH" || true
 
 if [ -z "$STATE_FILE" ]; then
+  SESSION_ID="${BRANCH#create/}"
   echo "homerun-worktree-setup: No matching state.json for session $SESSION_ID, skipping" >&2
   exit 0
 fi
-
-# Ensure docs directory exists
-mkdir -p "$WORKTREE_PATH/docs"
 
 # Copy tasks.json if it exists in the source worktree
 TASKS_FILE=$(jq -r '.tasks_file // "docs/tasks.json"' "$STATE_FILE")
 SOURCE_DIR=$(dirname "$STATE_FILE")
 if [ -f "$SOURCE_DIR/$TASKS_FILE" ]; then
+  mkdir -p "$WORKTREE_PATH/$(dirname "$TASKS_FILE")"
   cp "$SOURCE_DIR/$TASKS_FILE" "$WORKTREE_PATH/$TASKS_FILE"
 fi
 
+SESSION_ID="${BRANCH#create/}"
 echo "homerun-worktree-setup: Initialized worktree at $WORKTREE_PATH (session: $SESSION_ID)"

--- a/scripts/lib/feedback-aggregator.sh
+++ b/scripts/lib/feedback-aggregator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Library: feedback-aggregator.sh
 # Purpose: Extract reviewer rejection patterns from tasks.json and write them
 #          to feedback_patterns.json in the worktree.

--- a/scripts/lib/pkg-manager.sh
+++ b/scripts/lib/pkg-manager.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Shared: detect project package manager from lock files
+# Usage: source "$(dirname "$0")/lib/pkg-manager.sh"
+
+detect_pkg_manager() {
+  if [ -f bun.lockb ] || [ -f bun.lock ]; then
+    echo "bun"
+  elif [ -f pnpm-lock.yaml ]; then
+    echo "pnpm"
+  elif [ -f yarn.lock ]; then
+    echo "yarn"
+  else
+    echo "npm"
+  fi
+}

--- a/scripts/lib/session-state.sh
+++ b/scripts/lib/session-state.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Shared: session-aware state.json lookup
+# Usage: source "$(dirname "$0")/lib/session-state.sh"
+#        find_session_state "$WORKTREE_PATH"
+# Sets: STATE_FILE (path to matching state.json, or empty)
+
+find_session_state() {
+  local worktree_path="$1"
+  STATE_FILE=""
+
+  # First: check the current worktree directly
+  if [ -f "$worktree_path/state.json" ]; then
+    STATE_FILE="$worktree_path/state.json"
+    return 0
+  fi
+
+  # Find the parent session's state.json by matching session_id
+  local branch
+  branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  local session_id="${branch#create/}"
+
+  if [ -n "$session_id" ] && [ "$session_id" != "$branch" ]; then
+    local wt
+    for wt in $(git -C "$worktree_path" worktree list 2>/dev/null | awk '{print $1}'); do
+      [ "$wt" = "$worktree_path" ] && continue
+      if [ -f "$wt/state.json" ]; then
+        local file_session_id
+        file_session_id=$(jq -r '.session_id // empty' "$wt/state.json" 2>/dev/null)
+        if [ "$file_session_id" = "$session_id" ]; then
+          STATE_FILE="$wt/state.json"
+          return 0
+        fi
+      fi
+    done
+  fi
+
+  return 1
+}

--- a/skills/team-lead/SKILL.md
+++ b/skills/team-lead/SKILL.md
@@ -292,7 +292,7 @@ Task({
 
 ```bash
 # Update state.json
-jq '.phase = "completing" | .orchestration_completed_at = now' state.json | sponge state.json
+jq '.phase = "completing" | .orchestration_completed_at = now' state.json > state.json.tmp && mv state.json.tmp state.json
 
 # Or via Write tool:
 # Update state.json phase to "completing"


### PR DESCRIPTION
## Summary
- **validate-dag.sh**: Fix `grep -qw` → `grep -qF` for task IDs with regex metacharacters (`.`, `+`, `*`); fix numeric ID assumption with index-based ordering; fix JSON injection via unescaped file paths
- **task-completed.sh**: Use `detect_pkg_manager()` instead of parsing `packageManager` field from package.json
- **worktree-setup.sh**: `mkdir -p` for arbitrary `tasks_file` parent paths (not just `docs/`)
- **team-lead SKILL.md**: Replace `sponge` (moreutils) with portable `tmp+mv` pattern
- **scope-analyzer.md**: Add `Write` to tool permissions
- Extract `detect_pkg_manager` and session-state lookup into shared libs (`scripts/lib/`)
- Normalize all shebangs to `#!/usr/bin/env bash`

Closes #6

## Test plan
- [x] `bash scripts/homerun-validate-dag.sh` with regex metacharacter IDs (`task.1+alpha`) — passes
- [x] `bash scripts/homerun-validate-dag.sh` with quoted file paths — JSON properly escaped
- [x] Cycle detection works with metacharacter IDs
- [x] All scripts source shared libs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)