### PR TITLE
feat: eval expansion — scope-analysis, team-lead, quality-check, DAG scripts

### DIFF
--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -17,8 +17,20 @@ categories:
     skills: [homerun:task-decomposition]
 
   scope_analysis:
-    description: Tests for scope analysis skill
+    description: Tests for scope analysis skill (component extraction, AC validation)
     skills: [homerun:scope-analysis]
+
+  team_lead:
+    description: Tests for team-lead orchestration (dispatch loop, scale routing)
+    skills: [homerun:team-lead]
+
+  quality_check:
+    description: Tests for quality-check pipeline (phase ordering, signal output)
+    skills: [homerun:quality-check]
+
+  scripts:
+    description: Tests for shell scripts (DAG validation, hooks)
+    skills: []
 
   implement:
     description: Tests for implementer skill (TDD, code generation)

--- a/evals/quality-check/phase-ordering.eval.yaml
+++ b/evals/quality-check/phase-ordering.eval.yaml
@@ -1,0 +1,55 @@
+name: quality-check-phase-ordering
+description: "Verify quality-check follows correct phase order: lint → types → structure → tests → recheck"
+workflow: homerun:quality-check
+tags: [quality-check, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: package.json
+    content: |
+      {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+          "lint": "echo 'lint ok'",
+          "typecheck": "echo 'types ok'",
+          "test": "echo 'tests ok'"
+        }
+      }
+  - path: src/index.ts
+    content: |
+      export function add(a: number, b: number): number {
+        return a + b;
+      }
+  - path: tests/index.test.ts
+    content: |
+      import { add } from '../src/index';
+      test('add works', () => { expect(add(1, 2)).toBe(3); });
+
+input:
+  prompt: |
+    Run the quality check pipeline on this project.
+    Execute each phase in order and report results.
+    Emit a QUALITY_CHECK_COMPLETE signal when done.
+
+evaluations:
+  - type: behavioral
+    checks:
+      - output_contains: "[Ll]int|[Ff]ormat"
+      - output_contains: "[Tt]ype|[Tt]ypecheck"
+      - output_contains: "[Tt]est"
+
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate quality check execution:
+
+      1. Phase ordering (0-4): Followed correct order — lint first, then types, then structure, then tests, then recheck
+      2. Stop-on-failure awareness (0-2): Would stop at a failing phase before proceeding to next
+      3. Completeness (0-2): Executed or mentioned all 5 phases
+      4. Signal output (0-2): Emitted or described QUALITY_CHECK_COMPLETE signal with phase results
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/quality-check/signal-envelope.eval.yaml
+++ b/evals/quality-check/signal-envelope.eval.yaml
@@ -1,0 +1,49 @@
+name: quality-check-signal-envelope
+description: "Verify quality-check emits valid QUALITY_CHECK_COMPLETE signal"
+workflow: homerun:quality-check
+tags: [quality-check, signals, smoke, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: package.json
+    content: |
+      {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+          "lint": "echo 'ok'",
+          "test": "echo 'ok'"
+        }
+      }
+  - path: src/app.ts
+    content: |
+      export const greeting = "hello";
+
+input:
+  prompt: |
+    Run the quality check pipeline on this project.
+    When all phases pass, output a QUALITY_CHECK_COMPLETE signal
+    with the phase results summary.
+
+evaluations:
+  - type: behavioral
+    checks:
+      - signal_has:
+          field: "signal"
+          pattern: "QUALITY_CHECK_COMPLETE"
+      - output_contains: "pass|PASS|passed"
+
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate signal correctness:
+
+      1. Signal type (0-3): Emitted QUALITY_CHECK_COMPLETE (not a generic completion message)
+      2. Phase results (0-3): Signal includes results for each phase (lint, types, structure, tests, recheck)
+      3. Verdict (0-2): Clear pass/fail verdict in the signal
+      4. Format (0-2): Valid JSON signal envelope structure
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/scope-analysis/ac-validation.eval.yaml
+++ b/evals/scope-analysis/ac-validation.eval.yaml
@@ -1,0 +1,58 @@
+name: scope-analysis-ac-validation
+description: "Verify scope analyzer validates acceptance criteria testability"
+workflow: homerun:scope-analysis
+tags: [scope-analysis, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: state.json
+    content: |
+      {
+        "phase": "scope_analysis",
+        "session_id": "eval-scope-003",
+        "spec_paths": {
+          "prd": "docs/specs/PRD.md",
+          "adr": "docs/specs/ADR.md",
+          "technical_design": "docs/specs/TECHNICAL_DESIGN.md"
+        }
+      }
+  - path: docs/specs/PRD.md
+    content: |
+      # PRD: Notification Service
+      ## Acceptance Criteria
+      - AC-001: When a new order is placed, the customer receives an email within 5 minutes (quantitative — testable)
+      - AC-002: The notification system should be fast (vague — not testable)
+      - AC-003: Sending a notification to an invalid email returns an error with code INVALID_RECIPIENT (behavioral — testable)
+      - AC-004: The system should feel responsive (subjective — not testable)
+  - path: docs/specs/ADR.md
+    content: |
+      # ADR: Notification Service
+      ## Decision: Queue-based delivery via SQS
+  - path: docs/specs/TECHNICAL_DESIGN.md
+    content: |
+      # Technical Design: Notification Service
+      ## Components
+      - NotificationQueue (service): SQS-backed message queue
+      - EmailSender (service): SMTP email delivery
+
+input:
+  prompt: |
+    Analyze the acceptance criteria in the specs. Validate each for testability
+    using the standard patterns: behavioral, assertion, quantitative.
+    Mark any that are vague or subjective as untestable.
+
+evaluations:
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate acceptance criteria validation:
+
+      1. Testable identification (0-3): Correctly identified AC-001 and AC-003 as testable
+      2. Untestable identification (0-3): Correctly flagged AC-002 ("should be fast") and AC-004 ("feel responsive") as untestable
+      3. Pattern classification (0-2): Assigned correct patterns — AC-001 is quantitative, AC-003 is behavioral
+      4. Actionable feedback (0-2): Suggested how to make untestable criteria testable
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/scope-analysis/component-extraction.eval.yaml
+++ b/evals/scope-analysis/component-extraction.eval.yaml
@@ -1,0 +1,66 @@
+name: scope-analysis-component-extraction
+description: "Verify scope analyzer extracts components with correct layer classification"
+workflow: homerun:scope-analysis
+tags: [scope-analysis, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: state.json
+    content: |
+      {
+        "phase": "scope_analysis",
+        "session_id": "eval-scope-002",
+        "spec_paths": {
+          "prd": "docs/specs/PRD.md",
+          "adr": "docs/specs/ADR.md",
+          "technical_design": "docs/specs/TECHNICAL_DESIGN.md"
+        }
+      }
+  - path: docs/specs/PRD.md
+    content: |
+      # PRD: User Authentication
+      ## Requirements
+      - R1: Users can register with email and password
+      - R2: Users can log in with credentials
+      - R3: System issues JWT tokens on successful login
+      ## Acceptance Criteria
+      - AC-001: Registration creates user record in database
+      - AC-002: Login returns valid JWT token
+      - AC-003: Invalid credentials return 401 error
+  - path: docs/specs/ADR.md
+    content: |
+      # ADR: User Authentication
+      ## Decision: JWT with bcrypt
+      Use bcrypt for password hashing, JWT for session tokens.
+  - path: docs/specs/TECHNICAL_DESIGN.md
+    content: |
+      # Technical Design: User Authentication
+      ## Components
+      - UserModel (data): database schema for users table
+      - AuthService (service): handles registration, login, token generation
+      - AuthController (api): REST endpoints for /register and /login
+      - LoginForm (ui): frontend login/registration form
+      ## Non-Scope
+      - OAuth, social login, password reset
+
+input:
+  prompt: |
+    Analyze the specifications and extract a structured scope analysis.
+    Classify each component by layer (data, service, api, ui).
+    Validate all acceptance criteria for testability.
+
+evaluations:
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate component extraction accuracy:
+
+      1. Component identification (0-3): Found all 4 components (UserModel, AuthService, AuthController, LoginForm)
+      2. Layer classification (0-3): Correctly assigned layers — data, service, api, ui respectively
+      3. AC testability (0-2): Validated AC-001 through AC-003 as testable with specific assertions
+      4. Non-scope awareness (0-2): Identified OAuth, social login, password reset as out of scope
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/scope-analysis/signal-envelope.eval.yaml
+++ b/evals/scope-analysis/signal-envelope.eval.yaml
@@ -1,0 +1,76 @@
+name: scope-analysis-signal-envelope
+description: "Verify scope analyzer emits valid SCOPE_ANALYSIS_COMPLETE signal"
+workflow: homerun:scope-analysis
+tags: [scope-analysis, signals, smoke, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: state.json
+    content: |
+      {
+        "phase": "scope_analysis",
+        "session_id": "eval-scope-001",
+        "spec_paths": {
+          "prd": "docs/specs/PRD.md",
+          "adr": "docs/specs/ADR.md",
+          "technical_design": "docs/specs/TECHNICAL_DESIGN.md"
+        }
+      }
+  - path: docs/specs/PRD.md
+    content: |
+      # PRD: Counter Widget
+      ## Requirements
+      - R1: Display current count value
+      - R2: Increment button increases count by 1
+      - R3: Decrement button decreases count by 1
+      ## Acceptance Criteria
+      - AC-001: Counter displays initial value of 0
+      - AC-002: Clicking increment changes display from N to N+1
+      - AC-003: Clicking decrement changes display from N to N-1
+  - path: docs/specs/ADR.md
+    content: |
+      # ADR: Counter Widget
+      ## Decision: Web Component
+      Use vanilla web component for framework independence.
+  - path: docs/specs/TECHNICAL_DESIGN.md
+    content: |
+      # Technical Design: Counter Widget
+      ## Components
+      - CounterDisplay (ui): renders the count value
+      - CounterControls (ui): increment/decrement buttons
+      ## Non-Scope
+      - Persistence, animations, API integration
+
+input:
+  prompt: |
+    Run scope analysis on the specification documents listed in state.json.
+    Extract components, validate acceptance criteria for testability,
+    and create JIT context references.
+
+    Output a SCOPE_ANALYSIS_COMPLETE signal when done.
+
+evaluations:
+  - type: behavioral
+    checks:
+      - signal_has:
+          field: "signal"
+          pattern: "SCOPE_ANALYSIS_COMPLETE"
+      - output_contains: "[Cc]omponent|[Cc]ounter"
+      - output_contains: "AC-00[123]|acceptance"
+
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate scope analysis quality:
+
+      1. Component extraction (0-3): Identified CounterDisplay and CounterControls with layer classification
+      2. AC validation (0-3): All 3 acceptance criteria validated for testability
+      3. JIT context refs (0-2): Created pointers to spec locations rather than copying content
+      4. Signal completeness (0-2): Signal includes components_count, acceptance_criteria_count
+
+      Note: In eval context, file writing may not succeed. Focus on analysis quality.
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/scripts/dag-cycle.eval.yaml
+++ b/evals/scripts/dag-cycle.eval.yaml
@@ -1,0 +1,56 @@
+name: scripts-dag-cycle
+description: "Verify DAG validation script detects circular dependencies"
+workflow: homerun:implement
+tags: [scripts, dag, negative, homerun]
+timeout_seconds: 120
+isolation: tempdir
+
+fixtures:
+  - path: docs/tasks.json
+    content: |
+      {
+        "tasks": [
+          {
+            "id": "001", "title": "Task A", "objective": "Do A",
+            "acceptance_criteria": [{"id": "AC-001"}], "status": "pending",
+            "depends_on": ["003"], "task_type": "create_model",
+            "test_file": "tests/a.test.ts"
+          },
+          {
+            "id": "002", "title": "Task B", "objective": "Do B",
+            "acceptance_criteria": [{"id": "AC-002"}], "status": "pending",
+            "depends_on": ["001"], "task_type": "create_service",
+            "test_file": "tests/b.test.ts"
+          },
+          {
+            "id": "003", "title": "Task C", "objective": "Do C",
+            "acceptance_criteria": [{"id": "AC-003"}], "status": "pending",
+            "depends_on": ["002"], "task_type": "create_api",
+            "test_file": "tests/c.test.ts"
+          }
+        ]
+      }
+
+input:
+  prompt: |
+    Run the DAG validation script on docs/tasks.json.
+    This task graph has a circular dependency (001→003→002→001).
+    Report what the script finds.
+
+evaluations:
+  - type: behavioral
+    checks:
+      - output_contains: "[Cc]ycle|[Cc]ircular"
+
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate cycle detection:
+
+      1. Cycle detected (0-4): Correctly identified the circular dependency
+      2. Tasks identified (0-3): Named the tasks involved in the cycle (001, 002, 003)
+      3. Error severity (0-3): Reported this as a blocking error (not a warning)
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/scripts/dag-valid.eval.yaml
+++ b/evals/scripts/dag-valid.eval.yaml
@@ -1,0 +1,58 @@
+name: scripts-dag-valid
+description: "Verify DAG validation script passes on valid task graph"
+workflow: homerun:implement
+tags: [scripts, dag, smoke, homerun]
+timeout_seconds: 120
+isolation: tempdir
+
+fixtures:
+  - path: docs/tasks.json
+    content: |
+      {
+        "tasks": [
+          {
+            "id": "001", "title": "Create model", "objective": "Define schema",
+            "acceptance_criteria": [{"id": "AC-001"}], "status": "pending",
+            "depends_on": [], "task_type": "create_model",
+            "test_file": "tests/model.test.ts"
+          },
+          {
+            "id": "002", "title": "Create service", "objective": "Business logic",
+            "acceptance_criteria": [{"id": "AC-002"}], "status": "pending",
+            "depends_on": ["001"], "task_type": "create_service",
+            "test_file": "tests/service.test.ts"
+          },
+          {
+            "id": "003", "title": "Create API", "objective": "REST endpoints",
+            "acceptance_criteria": [{"id": "AC-003"}], "status": "pending",
+            "depends_on": ["002"], "task_type": "create_api",
+            "test_file": "tests/api.test.ts"
+          }
+        ]
+      }
+
+input:
+  prompt: |
+    Run the DAG validation script on docs/tasks.json.
+    The script is at the homerun plugin scripts directory.
+    Report whether the DAG is valid and what checks were performed.
+
+evaluations:
+  - type: behavioral
+    checks:
+      - output_contains: "valid|pass"
+      - output_contains: "dag|cycle|depend"
+
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate DAG validation execution:
+
+      1. Script execution (0-3): Successfully ran the validation script (or equivalent validation)
+      2. Result interpretation (0-3): Correctly reported the DAG as valid with no cycles
+      3. Check coverage (0-2): Mentioned checks performed (required fields, cycles, test files, dependencies)
+      4. Task count (0-2): Reported 3 tasks with correct dependency chain
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/team-lead/dispatch-loop.eval.yaml
+++ b/evals/team-lead/dispatch-loop.eval.yaml
@@ -1,0 +1,72 @@
+name: team-lead-dispatch-loop
+description: "Verify team-lead reads tasks, identifies ready tasks, and dispatches implementers"
+workflow: homerun:team-lead
+tags: [team-lead, homerun]
+timeout_seconds: 600
+isolation: tempdir
+
+fixtures:
+  - path: state.json
+    content: |
+      {
+        "phase": "implementing",
+        "session_id": "eval-tl-001",
+        "tasks_file": "docs/tasks.json",
+        "orchestration_mode": "skill",
+        "config": {
+          "max_parallel_tasks": 2,
+          "retries": { "same_agent": 1, "fresh_agent": 1 }
+        }
+      }
+  - path: docs/tasks.json
+    content: |
+      {
+        "tasks": [
+          {
+            "id": "001",
+            "title": "Create User model",
+            "objective": "Define User class with email validation",
+            "task_type": "create_model",
+            "status": "pending",
+            "depends_on": [],
+            "acceptance_criteria": [
+              { "id": "AC-001", "criterion": "User model validates email format" }
+            ],
+            "test_file": "tests/user.test.ts"
+          },
+          {
+            "id": "002",
+            "title": "Create Auth service",
+            "objective": "Implement login with JWT",
+            "task_type": "create_service",
+            "status": "pending",
+            "depends_on": ["001"],
+            "acceptance_criteria": [
+              { "id": "AC-002", "criterion": "Login returns valid JWT" }
+            ],
+            "test_file": "tests/auth.test.ts"
+          }
+        ]
+      }
+
+input:
+  prompt: |
+    You are the team-lead. Read state.json and tasks.json.
+    Identify which tasks are ready (dependencies resolved) and describe
+    how you would dispatch them. Do NOT actually spawn subagents.
+    Explain the dispatch order and reasoning.
+
+evaluations:
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate team-lead dispatch logic:
+
+      1. State reading (0-2): Correctly read state.json and tasks.json
+      2. Dependency analysis (0-3): Identified task 001 as ready (no deps) and task 002 as blocked (depends on 001)
+      3. Dispatch order (0-3): Would dispatch 001 first, then 002 after 001 completes
+      4. Config awareness (0-2): Referenced max_parallel_tasks or retry limits from config
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5

--- a/evals/team-lead/scale-routing.eval.yaml
+++ b/evals/team-lead/scale-routing.eval.yaml
@@ -1,0 +1,47 @@
+name: team-lead-scale-routing
+description: "Verify team-lead applies correct scale-based routing for task count"
+workflow: homerun:team-lead
+tags: [team-lead, homerun]
+timeout_seconds: 300
+isolation: tempdir
+
+fixtures:
+  - path: state.json
+    content: |
+      {
+        "phase": "implementing",
+        "session_id": "eval-tl-002",
+        "tasks_file": "docs/tasks.json",
+        "orchestration_mode": "skill"
+      }
+  - path: docs/tasks.json
+    content: |
+      {
+        "tasks": [
+          { "id": "001", "title": "Single task", "objective": "Do one thing",
+            "task_type": "create_model", "status": "pending", "depends_on": [],
+            "acceptance_criteria": [{"id": "AC-001", "criterion": "Works correctly"}],
+            "test_file": "tests/single.test.ts" }
+        ]
+      }
+
+input:
+  prompt: |
+    You are the team-lead. Read the tasks and determine the scale-based routing.
+    With only 1 task, what strategy should you use?
+    Describe how the dispatch would differ for 1-2 tasks vs 3-5 vs 6+ tasks.
+
+evaluations:
+  - type: llm_judge
+    model: haiku
+    max_tokens: 400
+    rubric: |
+      Evaluate scale-based routing awareness:
+
+      1. Small scale (0-3): For 1-2 tasks, correctly identifies sequential dispatch without worktree isolation
+      2. Medium scale (0-3): For 3-5 tasks, mentions parallel dispatch with worktree isolation
+      3. Large scale (0-2): For 6+ tasks, mentions batching or higher parallelism
+      4. Current case (0-2): Correctly applies small-scale strategy for the single task
+
+      Score 0-10. Pass threshold: 5
+    passing_score: 5


### PR DESCRIPTION
## Summary
- Add 9 new eval files covering previously untested phases (scope-analysis, team-lead, quality-check, DAG scripts)
- Update `evals/config.yaml` with new categories: `team_lead`, `quality_check`, `scripts`
- Eval count: 18 → 27 (50% increase)

### New evals
| Category | Eval | What it tests |
|----------|------|---------------|
| scope-analysis | signal-envelope | SCOPE_ANALYSIS_COMPLETE signal |
| scope-analysis | component-extraction | Component identification + layer classification |
| scope-analysis | ac-validation | AC testability validation (testable vs vague) |
| team-lead | dispatch-loop | Task dispatch with dependency analysis |
| team-lead | scale-routing | Scale-based routing strategy |
| quality-check | phase-ordering | lint→types→structure→tests→recheck order |
| quality-check | signal-envelope | QUALITY_CHECK_COMPLETE signal |
| scripts | dag-valid | Valid DAG passes validation |
| scripts | dag-cycle | Circular dependency detection |

References #7

## Test plan
- [x] All YAML files are syntactically valid
- [x] Eval patterns match existing conventions (behavioral + llm_judge)
- [x] Config.yaml categories reference correct skill names

🤖 Generated with [Claude Code](https://claude.com/claude-code)