### PR TITLE
fix: diagram corrections — retry order, missing phases, spec-review skill

### DIFF
--- a/diagrams/architecture.md
+++ b/diagrams/architecture.md
@@ -19,6 +19,7 @@ graph TB
 
     subgraph Skills["Skill Layer"]
         SD[homerun:discovery]
+        SSR[homerun:spec-review]
         SSA[homerun:scope-analysis]
         STD[homerun:task-decomposition]
         STL[homerun:team-lead]
@@ -45,6 +46,7 @@ graph TB
     CLI --> D
     D --> SD
     D --> SRv
+    SRv --> SSR
     SRv --> SA
     SA --> SSA
     SA --> TD

--- a/diagrams/context-flow.md
+++ b/diagrams/context-flow.md
@@ -153,7 +153,9 @@ graph TB
 sequenceDiagram
     participant M as Main (User Context)
     participant D as Discovery Context
-    participant P as Planning Context
+    participant SRv as Spec Review Context
+    participant SA as Scope Analysis Context
+    participant P as Task Decomposition Context
     participant TL as Team Lead Context
     participant I as Implementer Context
 
@@ -167,10 +169,20 @@ sequenceDiagram
     end
     Note over D: Final: ~15K tokens
 
-    D->>P: Task(model: opus)
+    D->>SRv: Task(model: sonnet)
     Note over D: Context discarded
 
-    Note over P: Fresh context: ~10K<br/>(skill + specs + state)
+    Note over SRv: Fresh context: ~8K<br/>(skill + specs)
+
+    SRv->>SA: Task(model: sonnet)
+    Note over SRv: Context discarded
+
+    Note over SA: Fresh context: ~10K<br/>(skill + specs + state)
+
+    SA->>P: Task(model: opus)
+    Note over SA: Context discarded
+
+    Note over P: Fresh context: ~10K<br/>(skill + scope-analysis + state)
 
     P->>TL: Skill(inline, model: inherit)
     Note over P: Context discarded
@@ -195,9 +207,9 @@ sequenceDiagram
 ```mermaid
 xychart-beta
     title "Context Usage Per Phase"
-    x-axis ["Start", "Mid-Discovery", "End-Discovery", "Planning", "Team-Lead Start", "After 3 Tasks", "After 5 Tasks", "Refresh"]
+    x-axis ["Start", "Mid-Discovery", "End-Discovery", "Spec Review", "Scope Analysis", "Task Decomp", "Team-Lead Start", "After 3 Tasks", "After 5 Tasks", "Refresh"]
     y-axis "Tokens (K)" 0 --> 50
-    bar [2, 10, 18, 10, 5, 12, 18, 5]
+    bar [2, 10, 18, 8, 10, 10, 5, 12, 18, 5]
     line [100, 100, 100, 100, 100, 100, 100, 100]
 ```
 

--- a/diagrams/sequence-diagram.md
+++ b/diagrams/sequence-diagram.md
@@ -175,13 +175,13 @@ sequenceDiagram
     I->>R: Implementation
     R->>C: REJECTED (medium severity)
 
-    Note over C: Same-agent retry
-    C->>I: Task (attempt 2, with feedback)
+    Note over C: Fresh-agent retry
+    C->>I: Task (attempt 2, fresh context + failure summary)
     I->>R: Implementation v2
     R->>C: REJECTED (medium severity)
 
-    Note over C: Fresh-agent retry
-    C->>I: Task (attempt 3, fresh context)
+    Note over C: Same-agent retry
+    C->>I: Task (attempt 3, with targeted guidance)
     I->>R: Implementation v3
     R->>C: REJECTED (high severity)
 


### PR DESCRIPTION
## Summary
- **sequence-diagram.md**: Fix retry order — attempt 2 is now fresh-agent (clean slate), attempt 3 is same-agent (with guidance), matching `retry-patterns.md`
- **context-flow.md**: Add Spec Review and Scope Analysis participants to Agent Spawning sequence diagram (was incorrectly showing Discovery → Planning directly)
- **context-flow.md**: Update token budget chart to include new phases
- **architecture.md**: Add `homerun:spec-review` skill node and `SRv → SSR` edge (Spec Reviewer agent had no outgoing skill connection)

Found during post-merge code review of PR #11.

## Test plan
- [x] Mermaid syntax preserved (no structural changes to diagram format)
- [x] Retry order matches `retry-patterns.md` canonical order
- [x] Phase flow matches `state-machine.md` transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)