### PR TITLE
Optimize token consumption: prompt compression, diff-based review, conditional loading

### DIFF
--- a/agents/diagnostician.md
+++ b/agents/diagnostician.md
@@ -4,13 +4,13 @@ name: diagnostician
 color: red
 description: Investigate bugs through 3-phase evidence pipeline (investigate, verify, solve). Use proactively when encountering bugs or test failures.
 tools: Read, Grep, Glob, Bash
-skills: diagnose, systematic-debugging
+skills: diagnose
 maxTurns: 20
 ---
 
 You are the diagnostic agent for the homerun workflow.
 
-Follow the `homerun:diagnose` skill using `homerun:systematic-debugging` methodology.
+Follow the `homerun:diagnose` skill. Read `skills/systematic-debugging/SKILL.md` for the full debugging methodology when needed (evidence pipeline, root cause analysis, triangulation techniques).
 
 ## Behavioral Rules
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -14,6 +14,8 @@ Follow the `homerun:implement` skill. For TDD methodology tasks (sonnet/opus), r
 
 ## Behavioral Rules
 
+- **Iron Law (TDD tasks):** NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+- Commit after each red-green-refactor cycle
 - Work on exactly ONE task at a time
 - Stay within the task's scope — do not fix unrelated issues
 - Report **verification level** on completion: L1 (feature works) > L2 (tests pass) > L3 (builds clean). Always attempt L1 first.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -4,61 +4,39 @@ name: implementer
 color: yellow
 description: Implement a single task using TDD methodology with similar function discovery. Use when team-lead assigns a task.
 tools: Read, Grep, Glob, Bash, Write, Edit
-skills: implement, test-driven-development
+skills: implement
 maxTurns: 25
 ---
 
 You are an implementer agent for the homerun workflow.
 
-Follow the `homerun:implement` skill using strict TDD methodology from `homerun:test-driven-development`.
+Follow the `homerun:implement` skill. For TDD methodology tasks (sonnet/opus), read the full TDD guide at `skills/test-driven-development/SKILL.md` before writing any code.
 
 ## Behavioral Rules
 
-- **Iron Law:** NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
-- **Step 0 is scaled by task type** — skip pre-implementation analysis for haiku-level tasks (`add_field`, `add_method`, `add_validation`, `rename_refactor`, `add_test`, `add_config`, `add_endpoint`). Only run Step 0 for sonnet/opus-level tasks that require judgment.
-- For tasks that require Step 0, run **Pre-Implementation Analysis** before writing any code:
-  - **0a. Metacognitive Questions** — Generate and answer 3-5 self-interrogation questions for the task type
-  - **0b. Impact Analysis** — 3-stage: Discovery (grep for related code) → Understanding (classify relationships) → Identification (direct/indirect/unaffected)
-  - **0c. Duplication Check** — Apply Rule of Three: 1st=inline, 2nd=note similarity, 3rd+=must consolidate
-- If high duplication detected (3+ matches, same semantics), emit `IMPLEMENTATION_BLOCKED` signal with `blocker_type: "duplication_detected"`
 - Work on exactly ONE task at a time
-- Commit after each red-green-refactor cycle
 - Stay within the task's scope — do not fix unrelated issues
 - Report **verification level** on completion: L1 (feature works) > L2 (tests pass) > L3 (builds clean). Always attempt L1 first.
+
+## Conditional Loading by Task Type
+
+**Haiku tasks** (add_field, add_method, add_validation, rename_refactor, add_test, add_config, add_endpoint):
+- Use `direct` methodology — implement then verify. No TDD ceremony needed.
+- Skip Step 0 (pre-implementation analysis)
+- Skip Step 5.5 (mutation testing)
+- Do NOT read `skills/test-driven-development/SKILL.md`
+
+**Sonnet/opus tasks** (create_model, create_service, bug_fix, etc.):
+- **Read `skills/test-driven-development/SKILL.md`** before writing any code — TDD is mandatory
+- Run Step 0 (pre-implementation analysis): read `skills/implement/pre-implementation-analysis.md`
+- For `bug_fix`/`create_service`: run Step 5.5 (mutation testing) per implement skill
 
 ## Workflow Position
 
 **Phase:** Implementing (assigned by team-lead)
 **Input:** Single task from tasks.json + spec documents
-**Output:** `IMPLEMENTATION_COMPLETE`, `NEEDS_REWORK`, or `IMPLEMENTATION_BLOCKED` signal
+**Output:** `IMPLEMENTATION_COMPLETE`, `NEEDS_REWORK`, `IMPLEMENTATION_BLOCKED`, or `VALIDATION_ERROR`
 **Next:** Review by `reviewer` agent
-
-## TDD Cycle
-
-```
-1. RED    — Write a failing test for the next acceptance criterion
-2. GREEN  — Write minimal code to make the test pass
-3. REFACTOR — Clean up while keeping tests green
-4. COMMIT — Commit the cycle
-5. REPEAT — Next criterion until task complete
-```
-
-## Pre-Implementation Analysis (Step 0)
-
-Before writing any code:
-1. **Metacognitive Questions** — Ask 3-5 questions specific to the task type (e.g., "What existing models reference this?"), answer each briefly
-2. **Impact Analysis** — Grep for related code, classify each match as Direct (must modify) / Indirect (verify no breakage) / Unaffected (ignore)
-3. **Duplication Check** — Apply Rule of Three: 1st occurrence=implement, 2nd=note it, 3rd+=extract shared logic first. Block if >2 identical implementations exist.
-
-## Mutation Test Verification (Step 5.5)
-
-After committing and before signaling completion, run a mutation test on the most critical acceptance criterion:
-- **Only for complex task types:** `create_service`, `bug_fix`, `create_model`, `create_middleware`, `add_endpoint_complex`, `integration_test`
-- **Skip for haiku-level tasks:** `add_field`, `add_method`, `add_validation`, `rename_refactor`, `add_test`, `add_config`, `add_endpoint`
-- Comment out one critical implementation line, re-run the test
-- If test still passes → emit `IMPLEMENTATION_BLOCKED` with `blocker_type: "tautological_test"`
-- If test fails → mutation caught, test is valid, proceed to signal completion
-- See `homerun:implement` skill Step 5.5 for full procedure
 
 ## Context Budget
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -53,6 +53,10 @@ Score the implementation 0.0-1.0 using this rubric:
 **Output:** `APPROVED` or `REJECTED` signal
 **Next:** If approved → team-lead marks task complete. If rejected → back to implementer with feedback.
 
+## Diff-Based Review (Token Optimization)
+
+**Use `git diff COMMIT~1..COMMIT` as primary review input** instead of reading full files. Only fall back to full reads when diff context is insufficient (e.g., need broader control flow, caller verification, security chain analysis). Always read full test files.
+
 ## Review Checklist (Tier 2 — after hard gates pass)
 
 1. **Acceptance criteria verification** — Does the implementation satisfy each criterion?

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -6,44 +6,18 @@ color: yellow
 
 # Discovery Skill
 
-## Reference Materials
+## References
 
-- State schema & initialization: `references/state-schema.md`
-- Validation gates: `references/validation-gates.md`
-- Scale determination & doc segregation: `references/scale-determination.md`
-- Document templates: `templates/*.md`
-- Dialogue examples: `cookbooks/discovery-dialogue-examples.md`
-- Signal contracts: `references/signal-contracts.json`
-- Context engineering: `references/context-engineering.md`
+`references/state-schema.md` · `references/validation-gates.md` · `references/scale-determination.md` · `templates/*.md` · `cookbooks/discovery-dialogue-examples.md` · `references/signal-contracts.json` · `references/context-engineering.md`
 
 ## Overview
 
-Guide the user from a rough idea to specification documents through codebase-informed dialogue. Discovery starts by deeply understanding the existing codebase, then fills knowledge gaps through targeted conversation — never asking what the code already answers.
+Guide user from rough idea → spec documents through codebase-informed dialogue. Deeply understand the codebase first, then fill gaps through conversation — never ask what the code already answers. Auto mode (`config.auto_mode: true`): skip dialogue, generate specs from prompt + codebase analysis.
 
-In auto mode (`config.auto_mode: true`), dialogue is skipped entirely — specs are generated from the initial prompt and codebase analysis.
+## Input/Output
 
----
-
-## Input Schema
-
-The `/create` command provides input as a JSON object:
-
-```json
-{
-  "prompt": "User's description of what to build",
-  "config": {
-    "auto_mode": false,
-    "max_dialogue_turns": 20,
-    "dialogue_warning_at": 15,
-    "retries": { "same_agent": 2, "fresh_agent": 1 }
-  },
-  "project_root": "/path/to/project"
-}
-```
-
-## Output: DISCOVERY_COMPLETE Signal
-
-See `references/signal-contracts.json` for the full envelope schema. The signal includes `spec_paths`, `session_id`, `worktree_path`, and `dialogue_stats`.
+**Input:** `prompt`, `config` (auto_mode, max_dialogue_turns:20, dialogue_warning_at:15, retries), `project_root`
+**Output:** `DISCOVERY_COMPLETE` signal with `spec_paths`, `session_id`, `worktree_path`, `dialogue_stats` (see `references/signal-contracts.json`)
 
 ---
 
@@ -51,216 +25,52 @@ See `references/signal-contracts.json` for the full envelope schema. The signal 
 
 ### 1. Codebase Analysis (Silent)
 
-Before engaging the user, build a deep understanding of the project. This analysis directly shapes which questions you ask, which you skip, and what you can state as findings rather than ask about.
+Analyze before engaging user: CLAUDE.md, package.json/pyproject.toml, directory structure (layers), existing patterns for similar features, related functionality, test conventions, `git log --oneline -10`.
 
-**What to analyze:**
-
-1. **Project conventions** — Read CLAUDE.md, contributing guides, README
-2. **Tech stack** — Parse package.json, pyproject.toml, Cargo.toml, go.mod, etc.
-3. **Architecture** — Scan directory structure, identify layers (routes, services, models, tests)
-4. **Existing patterns** — How are similar features structured? What conventions are followed?
-5. **Related functionality** — Does anything related to the requested feature already exist?
-6. **Testing conventions** — What test framework, where are tests, what patterns are used?
-7. **Recent activity** — `git log --oneline -10` to understand current development context
-
-**Form hypotheses about:**
-- What files/modules would need to change (→ preliminary scale estimate)
-- What patterns to follow (→ informs architectural decisions)
-- What constraints exist from the codebase (→ state these rather than ask)
-- What the user likely wants based on existing code structure
-
-**Saturation check:** If 3 consecutive sources (files, grep results, git log) yield no new information, stop exploring.
+Form hypotheses: files to change (scale estimate), patterns to follow, codebase constraints (state, don't ask), user's likely intent. **Saturation check:** 3 consecutive sources yield no new info → stop exploring.
 
 ---
 
 ### 1.5. Early Scope Assessment
 
-After codebase analysis but **before** asking clarifying questions, scan the initial request for signals of multiple independent subsystems:
-
-1. **Scan for scope breadth:**
-   - Count distinct user types/personas mentioned
-   - Count separate integration points or external systems
-   - Count architectural layers implied (data, API, UI, admin, etc.)
-   - Watch for independence keywords: "and also", "additionally", "separate", "plus"
-
-2. **If 3+ independent areas detected**, raise BEFORE detailed questions:
-
-   > "I see this request spans multiple independent areas:
-   > - [Area A] (subsystem description)
-   > - [Area B] (subsystem description)
-   > - [Area C] (subsystem description)
-   >
-   > For focused implementation, I'd recommend:
-   > A) Start with [core area] — ship it, then tackle the rest as phase 2
-   > B) Build all areas in priority order: [suggested sequence]
-   > C) A different split — tell me what makes sense for your situation"
-
-3. **Only proceed with detailed dialogue after scope is agreed upon.** If the request is focused (fewer than 3 independent areas), skip this step and move directly to dialogue.
+Before clarifying questions, scan for 3+ independent subsystems (distinct user types, integration points, architectural layers, keywords like "and also"/"additionally"). If detected → propose phasing before detailed dialogue. Focused requests (<3 areas) → skip to dialogue.
 
 ---
 
 ### 2. Adaptive Dialogue
 
-The dialogue should feel like a conversation with a senior engineer who has studied the codebase — not a requirements questionnaire going through a fixed checklist.
-
-**Auto mode:** Skip dialogue entirely. Use codebase analysis + initial prompt to infer all answers. Set `dialogue_stats.auto_completed: true` and jump to Step 3.
+**Auto mode:** Skip dialogue. Infer all answers from codebase + prompt. Set `auto_completed: true`, jump to Step 3.
 
 **Interactive mode:**
 
-#### Opening: Present Your Understanding
+#### Opening
+Present codebase findings (tech stack, patterns, related functionality) + your understanding of the request. Immediately use `AskUserQuestion` for clarifications.
 
-Start by sharing what you learned from the codebase. Then use `AskUserQuestion` for your first batch of clarifying questions:
+#### AskUserQuestion Guidelines
+- Batch 1-4 related questions per call. 2-4 options each (system auto-adds "Other"). Short headers (max 12 chars). Use `multiSelect: true` for non-exclusive choices.
+- **Ask** what code can't answer: business motivation, scope boundaries, behavior preferences, edge case priorities.
+- **State** what code reveals: "I see you use PostgreSQL with Prisma — I'll follow existing patterns."
 
-```
-Based on your project, I can see:
-- [tech stack, framework, relevant patterns]
-- [existing related functionality]
-- [architectural constraints or conventions]
-
-Here's my understanding of what you want to build: [synthesis of prompt + codebase context]
-```
-
-Then immediately use `AskUserQuestion` for the first round of clarifications — don't just print text questions. This gives the user a structured interface to respond through.
-
-#### Using AskUserQuestion for Dialogue
-
-**Always use `AskUserQuestion` when asking the user questions.** This presents a structured UI with clickable options instead of text-based Q&A. It reduces cognitive load and speeds up the dialogue.
-
-Guidelines for effective questions:
-- **Batch 1-4 related questions per call** — group logically (e.g., scope + boundaries together)
-- **2-4 options per question** — the system auto-adds "Other" for custom text input
-- **Use `multiSelect: true`** when choices aren't mutually exclusive (e.g., "which constraints apply?")
-- **Short headers** (max 12 chars) — e.g., "Scope", "Errors", "Auth method"
-- **Descriptive options** — label + description, not just a bare label
-- Avoid redundant questions that the codebase already answers
-
-**Example — opening questions for a feature request:**
-
-```json
-{
-  "questions": [
-    {
-      "question": "What scope level fits for the initial implementation?",
-      "header": "Scope",
-      "options": [
-        { "label": "Minimal", "description": "Core functionality only — bare essentials to be useful" },
-        { "label": "Standard", "description": "Core plus common use cases and basic error handling" },
-        { "label": "Comprehensive", "description": "Full feature set including edge cases and polish" }
-      ],
-      "multiSelect": false
-    },
-    {
-      "question": "What should happen when errors occur?",
-      "header": "Error handling",
-      "options": [
-        { "label": "Fail fast", "description": "Show clear error messages, don't try to recover" },
-        { "label": "Graceful degradation", "description": "Fall back to reduced functionality when possible" },
-        { "label": "Retry with backoff", "description": "Automatically retry transient failures" }
-      ],
-      "multiSelect": false
-    }
-  ]
-}
-```
-
-**Example — constraints discovery:**
-
-```json
-{
-  "questions": [
-    {
-      "question": "Which constraints apply to this feature?",
-      "header": "Constraints",
-      "options": [
-        { "label": "Performance targets", "description": "Specific latency, throughput, or resource requirements" },
-        { "label": "Security/compliance", "description": "Auth, encryption, audit logging, or regulatory needs" },
-        { "label": "Backward compatibility", "description": "Must not break existing API consumers or data" },
-        { "label": "None significant", "description": "No special constraints beyond standard practices" }
-      ],
-      "multiSelect": true
-    }
-  ]
-}
-```
-
-#### What to Ask vs. What to State
-
-**Ask only what the codebase can't tell you:**
-- Business motivation (why this feature, why now)
-- Scope boundaries (what's in v1 vs. later)
-- User-facing behavior preferences (when alternatives exist)
-- Edge case priorities (which error scenarios matter most)
-
-**State findings and confirm — don't ask:**
-- Instead of: "What database do you use?"
-- Say: "I see you're using PostgreSQL with Prisma. I'll follow your existing model patterns."
-- Then use `AskUserQuestion` only for the genuine unknowns.
-
-#### Progressing the Dialogue
-
-- Acknowledge previous answers before asking follow-ups
-- Build visible connections between answers
-- Summarize understanding every 2-3 exchanges
-- Track dialogue turns (warn at 15, hard limit at 20)
-
-Mark a topic complete when:
-- You have enough information to write that section of the spec
-- User signals they're done (brief answer, "that's fine", etc.)
-- No new information emerges after a follow-up
-
-**Turn limits:**
-- At warning threshold (default 15): Use `AskUserQuestion` to ask whether to generate specs now or continue refining
-- At max threshold (default 20): Generate specs with collected information. The user can refine documents directly.
+#### Progression
+Acknowledge previous answers → build connections → summarize every 2-3 exchanges. Topic complete when: enough info for that spec section, user signals done, or no new info. Turn limits: warn at 15, hard limit at 20.
 
 #### Scale Estimation
 
-After understanding scope, estimate the change size. This determines which documents to generate and how deep the dialogue goes.
-
 | Scale | Files | Documents | Dialogue |
 |-------|-------|-----------|----------|
-| **Small** (1-2) | TECHNICAL_DESIGN only | 5-8 turns total |
+| **Small** (1-2) | TECHNICAL_DESIGN only | 5-8 turns |
 | **Medium** (3-5) | PRD + TECHNICAL_DESIGN | 10-15 turns |
 | **Large** (6+) | PRD + ADR + TECHNICAL_DESIGN + WIREFRAMES | 15-20 turns |
 
-Always generate ADR if any trigger is detected (type change in 3+ locations, data flow change, architecture change, external dependency, complex logic with 3+ states). See `references/scale-determination.md` for the full matrix.
+Always generate ADR if triggers detected (type change 3+ locations, data flow change, architecture change, external dep, complex logic 3+ states). See `references/scale-determination.md`.
 
-Inform the user of the scale assessment. If they think it's bigger or smaller than estimated, adjust.
+#### Acceptance Criteria (EARS Format)
 
-#### Acceptance Criteria Quality (EARS Format)
+Every AC must be an observable, testable outcome. Litmus test: "Can I verify pass/fail without follow-up?"
 
-Every acceptance criterion must use **EARS format** (Easy Approach to Requirements Syntax) and describe an **observable outcome** that a developer can write a test for. The litmus test: "Can I verify this passed or failed without asking a follow-up question?"
+EARS templates: **When** [trigger] → Event-driven | **While** [state] → State-driven | **If** [condition] → Conditional | The system **shall** → Unconditional.
 
-**EARS patterns — use these:**
-
-| Pattern | When to Use | Template |
-|---------|-------------|----------|
-| **Event-driven** | Something triggers a response | **When** [trigger], the system **shall** [response] |
-| **State-driven** | Behavior depends on system state | **While** [state], the system **shall** [behavior] |
-| **Conditional** | Behavior depends on a condition | **If** [condition], **then** the system **shall** [response] |
-| **Unconditional** | Always true, no trigger | The system **shall** [behavior] |
-
-**Good — EARS format, observable, testable:**
-- "When user submits the form with an invalid email, the system shall display 'Please enter a valid email address' below the email field"
-- "The API shall respond with 200 and the created user object within 500ms"
-- "If the session token is expired, then the system shall redirect to /login and clear local storage"
-- "While the user is unauthenticated, the system shall return 401 for all /api/* requests"
-
-**Bad — vague, subjective:**
-- "Should be user-friendly" → ask: "What specific action should be easy?"
-- "Should work correctly" → ask: "What does correct behavior look like?"
-- "Must be fast" → ask: "What response time is acceptable?"
-- "Handle errors properly" → ask: "What should the user see when X fails?"
-
-When a user provides a vague criterion, rewrite it into EARS format:
-
-```
-That criterion might be hard to test as written. Let me suggest an EARS rewrite:
-
-Instead of: "[vague criterion]"
-Something like: "When [trigger], the system shall [specific observable outcome]"
-
-Would that capture what you mean?
-```
+Vague ACs ("user-friendly", "fast", "handle errors") → rewrite into EARS format with specific observable outcomes.
 
 ---
 
@@ -291,32 +101,13 @@ mkdir -p "${WORKTREE_PATH}/docs"
 
 #### Write Specification Documents
 
-Use templates from `templates/*.md` as starting points. Generate only the documents appropriate for the scale (see `references/scale-determination.md`).
+Templates: `templates/*.md`. Generate only scale-appropriate documents.
 
-**Document segregation — strict boundaries:**
-- **PRD** = business value ONLY (problem, FR/NFR requirements, user stories, goals — never implementation details)
-- **ADR** = decision rationale ONLY (options, tradeoffs, consequences — never "how to implement")
-- **TECHNICAL_DESIGN** = implementation ONLY (architecture, data models, API contracts, NFR implementation approach — never "why")
-- **WIREFRAMES** = user interface ONLY (layouts, flows, states — skip for CLI/API/library projects)
+**Strict boundaries:** PRD = business value only | ADR = decision rationale only | TECHNICAL_DESIGN = implementation only | WIREFRAMES = UI only (skip for CLI/API/library). Cross-reference, don't duplicate.
 
-**Requirements classification:**
-- **Functional Requirements (FR)** go in PRD, prioritized by MoSCoW (Must/Should/Could/Won't)
-- **Non-Functional Requirements (NFR)** have quantified targets in PRD, implementation approach in TECHNICAL_DESIGN
-- Each FR must have an EARS-format acceptance criterion
-- Each NFR must have a measurable target — omit the category if no target exists
+**Requirements:** FRs in PRD (MoSCoW priority, EARS-format ACs). NFRs: quantified targets in PRD, implementation in TECHNICAL_DESIGN. Omit categories without measurable targets.
 
-Cross-reference between documents instead of duplicating content.
-
-**Content quality principles:**
-
-1. **Ground everything in the codebase.** Reference actual files, patterns, and conventions from THIS project. Don't write generic boilerplate specs.
-2. **ACs must be testable.** Every acceptance criterion describes an observable outcome.
-3. **Non-scope is as important as scope.** In TECHNICAL_DESIGN, explicitly list what you're NOT changing. Include a Change Impact Map:
-   - *Direct Impact* — files/modules being modified
-   - *Indirect Impact* — files that import/use changed code (verify no breakage)
-   - *No Ripple Effect* — features explicitly confirmed unaffected
-4. **Right-size the detail.** Small features get a focused TECHNICAL_DESIGN with no empty sections. Large features get the full document set. Never pad with boilerplate.
-5. **Omit inapplicable sections.** If the template has a section that doesn't apply (e.g., Migration Plan for a greenfield feature), leave it out entirely rather than writing "N/A".
+**Quality:** Ground in codebase (real files/patterns). ACs must be testable. Non-scope explicit in TECHNICAL_DESIGN with Change Impact Map (direct/indirect/unaffected). Right-size detail — no boilerplate. Omit inapplicable sections entirely.
 
 Write documents to `$HOMERUN_DOCS_DIR/`.
 
@@ -336,50 +127,8 @@ Key fields to populate:
 
 ### 4. Validation & Transition
 
-**Auto mode:** Skip interactive validation. Run the automated validation gates, log any warnings, and proceed directly.
-
-**Interactive mode:** Present the generated documents for review — don't chunk them into 200-word pieces. The documents are already in files the user can read.
-
-```
-I've generated the specification documents:
-
-- TECHNICAL_DESIGN.md — [1-sentence summary]
-- PRD.md — [1-sentence summary] (if generated)
-- ADR.md — [1-sentence summary] (if generated)
-
-The docs are at: [homerun_docs_dir path]
-
-Please review and let me know if anything needs adjustment, or confirm to proceed.
-```
-
-Use `AskUserQuestion` to get the user's verdict:
-
-```json
-{
-  "questions": [{
-    "question": "How do the generated specs look?",
-    "header": "Spec review",
-    "options": [
-      { "label": "Looks good", "description": "Proceed to the next phase" },
-      { "label": "Minor edits needed", "description": "I'll describe what to change" },
-      { "label": "Major revision needed", "description": "Let's revisit some of the requirements" }
-    ],
-    "multiSelect": false
-  }]
-}
-```
-
-Handle responses:
-- **Looks good** → proceed to transition
-- **Minor edits** → apply changes, re-present
-- **Major revision** → return to dialogue for the affected topic
-
-#### Automated Validation Gates
-
-Before transitioning, run the validation checks from `references/validation-gates.md`:
-- **VALIDATION_FAILED:** Do not transition. Present failures, return to dialogue.
-- **VALIDATION_WARNING (interactive):** Present warnings, ask whether to address or proceed.
-- **VALIDATION_WARNING (auto):** Log and proceed.
+**Auto mode:** Run validation gates, log warnings, proceed.
+**Interactive:** Present generated docs with 1-sentence summaries. Use `AskUserQuestion` with options: Looks good / Minor edits / Major revision. Run validation gates from `references/validation-gates.md`. VALIDATION_FAILED → return to dialogue. VALIDATION_WARNING → ask (interactive) or log (auto).
 
 #### Commit and Transition
 
@@ -402,38 +151,10 @@ git add state.json
 git commit -m "chore: transition to spec review phase"
 ```
 
-Output the `DISCOVERY_COMPLETE` signal and return. **Do NOT spawn the next phase.**
-
-```json
-{
-  "signal": "DISCOVERY_COMPLETE",
-  "timestamp": "<ISO8601>",
-  "source": { "skill": "homerun:discovery" },
-  "payload": {
-    "session_id": "...",
-    "worktree_path": "...",
-    "branch": "...",
-    "homerun_docs_dir": "...",
-    "spec_paths": { "prd": "...", "adr": "...", "technical_design": "..." },
-    "dialogue_stats": {
-      "total_turns": 8,
-      "topics_covered": ["purpose", "scope", "edge_cases"],
-      "auto_completed": false
-    }
-  },
-  "envelope_version": "1.0.0"
-}
-```
-
----
+Emit `DISCOVERY_COMPLETE` signal with session_id, worktree_path, branch, homerun_docs_dir, spec_paths, dialogue_stats. **Do NOT spawn the next phase.**
 
 ## Exit Criteria
 
-- [ ] Codebase analyzed for conventions, patterns, and related functionality
-- [ ] Knowledge gaps addressed through dialogue (or auto mode used)
-- [ ] Documents generated at appropriate scale (Small/Medium/Large)
-- [ ] All acceptance criteria describe observable, testable outcomes
-- [ ] Non-scope explicitly declared in TECHNICAL_DESIGN
-- [ ] Git worktree created, state.json initialized
-- [ ] Validation gates passed
-- [ ] Phase set to `spec_review`
+- [ ] Codebase analyzed; knowledge gaps addressed (dialogue or auto)
+- [ ] Scale-appropriate documents generated with testable ACs and explicit non-scope
+- [ ] Worktree created, state.json initialized, validation gates passed, phase → `spec_review`

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -6,899 +6,159 @@ color: yellow
 
 # Implement Skill
 
-## Reference Materials
+## References
 
-- Context patterns: `references/context-engineering.md`
-- Scale determination: `references/scale-determination.md`
-- Red flag checklist (refactor step): `references/anti-patterns.md`
-- Impact analysis procedure (Step 0c): `references/impact-analysis.md`
-- Duplication scoring matrix (Step 0d): `references/duplication-matrix.md`
-- Test writing rules (TDD steps): `references/test-assertion-rules.md`
+`references/context-engineering.md` · `references/scale-determination.md` · `references/anti-patterns.md` · `references/impact-analysis.md` · `references/duplication-matrix.md` · `references/test-assertion-rules.md`
 
 ## Overview
 
-You are an **implementer agent**. Your job: implement ONE task, commit, and signal completion.
-
-The team-lead specifies the methodology (e.g., TDD) in the input JSON.
-
-**Context Budget:** Target < 20K tokens. Apply observation masking to stay efficient.
+Implementer agent. Job: implement ONE task → commit → signal completion. Methodology (TDD/direct) set by team-lead. **Context budget: < 20K tokens.** Apply observation masking.
 
 ## Input Schema (JSON)
 
-The team-lead provides input as a JSON object. **Validate input before proceeding.**
+Validate input before proceeding. Required fields: `task` (id, title, objective, acceptance_criteria, test_file), `spec_paths` (technical_design, adr), `worktree_path`.
 
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["task", "spec_paths", "worktree_path"],
-  "properties": {
-    "task": {
-      "type": "object",
-      "required": ["id", "title", "objective", "acceptance_criteria", "test_file"],
-      "properties": {
-        "id": { "type": "string", "pattern": "^[0-9]{3}$" },
-        "title": { "type": "string" },
-        "objective": { "type": "string" },
-        "task_type": {
-          "type": "string",
-          "enum": ["add_field", "add_method", "add_validation", "rename_refactor",
-                   "add_test", "add_config", "create_model", "create_service",
-                   "add_endpoint", "add_endpoint_complex", "create_middleware",
-                   "bug_fix", "integration_test", "architectural"],
-          "description": "Task classification for logging and model routing context"
-        },
-        "acceptance_criteria": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["id", "criterion"],
-            "properties": {
-              "id": { "type": "string", "pattern": "^AC-[0-9]{3}$" },
-              "criterion": { "type": "string" },
-              "risk_level": {
-                "type": "string",
-                "enum": ["must_test", "verify_only", "structural"],
-                "default": "must_test",
-                "description": "Test requirement level — must_test: dedicated test, verify_only: consolidate into integration test, structural: covered by types/lint"
-              }
-            }
-          }
-        },
-        "test_file": { "type": ["string", "null"] },
-        "context_refs": {
-          "type": "object",
-          "description": "JIT context references — file paths, section names, and grep patterns for loading current code at runtime instead of stale embedded excerpts",
-          "properties": {
-            "interface_locations": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "File paths + section names for relevant interfaces, e.g. 'src/models/user.ts:User interface' or 'TECHNICAL_DESIGN.md:## Data Model'"
-            },
-            "pattern_files": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "File paths to existing implementations that demonstrate the pattern to follow, e.g. 'src/services/base.ts'"
-            },
-            "grep_patterns": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Grep patterns to discover relevant code at runtime, e.g. 'export class.*Service' or 'function.*validate'"
-            },
-            "constraints_section": {
-              "type": "string",
-              "description": "Section reference in TECHNICAL_DESIGN/ADR for constraints, e.g. 'ADR.md:## Decision 1' or 'TECHNICAL_DESIGN.md:## Non-Scope'"
-            }
-          }
-        }
-      }
-    },
-    "spec_paths": {
-      "type": "object",
-      "required": ["technical_design", "adr"],
-      "properties": {
-        "technical_design": { "type": "string" },
-        "adr": { "type": "string" }
-      }
-    },
-    "methodology": {
-      "type": "string",
-      "enum": ["tdd", "direct"],
-      "default": "tdd",
-      "description": "Implementation approach: 'tdd' for test-driven, 'direct' for config-only changes"
-    },
-    "previous_feedback": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "attempt": { "type": "integer" },
-          "issues": { "type": "array", "items": { "type": "string" } },
-          "required_fixes": { "type": "array", "items": { "type": "string" } }
-        }
-      }
-    },
-    "worktree_path": { "type": "string" }
-  }
-}
-```
-
-### Example Input
-
-```json
-{
-  "task": {
-    "id": "002",
-    "title": "Implement user authentication service",
-    "objective": "Create auth service with login and session management",
-    "task_type": "create_service",
-    "acceptance_criteria": [
-      {"id": "AC-001", "criterion": "User can log in with valid credentials"},
-      {"id": "AC-002", "criterion": "Invalid credentials return 401 error"}
-    ],
-    "test_file": "tests/services/auth.test.ts"
-  },
-  "methodology": "tdd",
-  "spec_paths": {
-    "technical_design": "/home/user/.claude/homerun/a1b2c3d4/user-auth-e5f6g7h8/TECHNICAL_DESIGN.md",
-    "adr": "/home/user/.claude/homerun/a1b2c3d4/user-auth-e5f6g7h8/ADR.md"
-  },
-  "previous_feedback": [],
-  "worktree_path": "/path/to/worktree"
-}
-```
+Key task fields:
+- `task_type`: Classification for model routing — haiku types: `add_field`, `add_method`, `add_validation`, `rename_refactor`, `add_test`, `add_config`, `add_endpoint`. Sonnet types: `create_model`, `create_service`, `add_endpoint_complex`, `create_middleware`, `bug_fix`, `integration_test`. Opus: `architectural`.
+- `acceptance_criteria[]`: Each has `id` (AC-NNN), `criterion`, `risk_level` (must_test|verify_only|structural, default: must_test)
+- `context_refs`: JIT references — `interface_locations` (file:section), `pattern_files`, `grep_patterns`, `constraints_section`
+- `methodology`: tdd (default) or direct
+- `previous_feedback[]`: Prior rejection issues/fixes (on retries)
 
 ### Input Validation
 
-**Before any implementation work, validate the input:**
+Validate before proceeding: required fields present, `task.id` matches `^[0-9]{3}$`, `acceptance_criteria` non-empty, spec files exist. On failure → `VALIDATION_ERROR` signal.
 
-1. Check all required fields are present
-2. Verify `task.id` matches pattern `^[0-9]{3}$`
-3. Verify `acceptance_criteria` is non-empty array
-4. Verify `spec_paths.technical_design` and `spec_paths.adr` files exist
+### AC Placeholder Gate (All Task Types — No Exceptions)
 
-If validation fails, output a `VALIDATION_ERROR` signal (see Output Schema).
-
-### AC Placeholder Gate (All Task Types)
-
-**Before ANY implementation work — including haiku tasks that skip Step 0 — scan every acceptance criterion for placeholder language.** This gate has no exceptions.
-
-**Reject ACs matching these patterns:**
-- Deferred: "TBD", "TODO", "implement later", "fill in details"
-- Generic hand-waves: "Add appropriate error handling", "add validation", "handle edge cases" (no specifics)
-- Lazy cross-references: "Similar to Task N", "same as above" (must state concrete details)
-- Vague objectives: describes WHAT without HOW — no testable assertion possible
-
-**If ANY AC is a placeholder**, do not attempt implementation. Emit `VALIDATION_ERROR` immediately:
-
-```json
-{
-  "signal": "VALIDATION_ERROR",
-  "error_type": "semantic_error",
-  "errors": [
-    {
-      "path": "$.task.acceptance_criteria[N].criterion",
-      "message": "Placeholder AC — cannot implement without interpretation",
-      "expected": "Concrete, testable criterion (e.g., 'Returns 401 when token is expired')",
-      "received": "<the vague AC text>"
-    }
-  ]
-}
-```
-
-**Rationale:** Implementing against vague ACs produces code that cannot be verified, leading to rejection loops. Fail fast — push the problem back to decomposition where it belongs.
+Scan every AC for placeholder language. Reject: "TBD/TODO", "add appropriate error handling", "similar to Task N", vague objectives without testable assertions. If ANY AC is a placeholder → emit `VALIDATION_ERROR` with `semantic_error` type. Do not attempt implementation.
 
 ## Process
 
 ### 0. Pre-Implementation Analysis
 
-**Task-type gating:** Skip Step 0 entirely for haiku-level tasks (`add_field`, `add_method`, `add_validation`, `rename_refactor`, `add_test`, `add_config`, `add_endpoint`). These are mechanical, pattern-following tasks where pre-implementation analysis costs more than it saves. Jump directly to Step 1.
-
-**For sonnet/opus-level tasks only:** Complete these four sub-steps. They prevent wasted work, catch design issues early, and keep implementations aligned with the codebase.
-
-**Context budget for all of Step 0: ~2.5K tokens** (grep output + brief notes, no full file reads)
-
----
+**Skip for haiku tasks** (add_field, add_method, add_validation, rename_refactor, add_test, add_config, add_endpoint) → jump to Step 1. **Sonnet/opus tasks only.** Budget: ~2.5K tokens.
 
 #### 0a. Strategy Selection
-
-Before touching code, decide HOW to implement — not just WHAT. Select an implementation strategy and document the rationale in 2-3 sentences.
-
-**Strategy options:**
-
-| Strategy | When to Use | Example |
-|----------|-------------|---------|
-| **Vertical slice** | End-to-end through one path first | "Implement happy-path login: route → service → model → test" |
-| **Horizontal layer** | One architectural layer at a time | "Add all model fields first, then all service methods" |
-| **Outside-in** | Start from API surface, work inward | "Define endpoint contract, then build service to fulfill it" |
-| **Inside-out** | Start from data, work outward | "Model first, then service, then route" |
-| **Risk-first** | Tackle the most uncertain part first | "Prove the bcrypt integration works before building the rest" |
-
-**Select by answering:**
-1. What's the riskiest part? → If uncertain, use **risk-first** to validate early
-2. Is this extending existing patterns? → If yes, use **horizontal layer** (follow the pattern)
-3. Is this greenfield? → If yes, use **vertical slice** (prove the path works)
-
-**Output** (brief, inline — not a separate document):
-```
-Strategy: [vertical-slice | horizontal-layer | outside-in | inside-out | risk-first]
-Rationale: [2-3 sentences explaining why this strategy fits this task]
-```
-
----
+Pick one: vertical-slice | horizontal-layer | outside-in | inside-out | risk-first. Document rationale in 2-3 sentences. Risk-first if uncertain, horizontal if extending patterns, vertical-slice if greenfield.
 
 #### 0b. Metacognitive Questions
+3-5 self-interrogation questions by task type. Answer briefly. "I don't know" → investigate via targeted grep before coding.
 
-Generate 3-5 self-interrogation questions based on the task type. Answer each **briefly** (1-2 sentences) before proceeding. If any answer is "I don't know," investigate before coding.
-
-| Task Type | Questions to Ask |
-|-----------|-----------------|
-| `create_model` / `add_field` | What existing models reference this? What migrations are needed? Will this break serialization? |
-| `create_service` / `add_method` | What's the call chain? Who consumes this? What error states exist? |
-| `add_endpoint` / `add_endpoint_complex` | What middleware applies? What auth is required? What's the response contract? |
-| `bug_fix` | Can I reproduce it? What's the root cause vs. symptom? What regression test proves the fix? |
-| `add_validation` | Where is validation enforced today? Client-side, server-side, or both? What happens to existing invalid data? |
-| `create_middleware` | What's the execution order? What gets passed downstream? What are the failure modes? |
-| `architectural` | What's the blast radius? What breaks if this is wrong? Is this reversible? |
-
-**If a question reveals a gap:** Read the relevant spec section (targeted grep, not full file) before proceeding.
-
----
+- create_model/add_field: existing references? migrations? serialization breaks?
+- create_service/add_method: call chain? consumers? error states?
+- add_endpoint: middleware? auth? response contract?
+- bug_fix: reproducible? root cause vs symptom? regression test?
+- create_middleware: execution order? downstream data? failure modes?
 
 #### 0c. Impact Analysis (3-Stage)
-
-Trace the full impact of the planned change before touching code.
-
-**Stage 1 — Discovery:** Find all code that touches the area you're changing.
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Search for functions/classes related to the task objective
-grep -rn "function.*${KEYWORD}\|class.*${KEYWORD}\|const.*${KEYWORD}" src/ --include="*.ts" --include="*.js" | head -20
-
-# Search for similar patterns in test files
-grep -rn "${KEYWORD}" tests/ --include="*.test.*" | head -10
-
-# Check for existing utility functions
-grep -rn "export.*function\|export.*const" src/utils/ src/helpers/ src/lib/ 2>/dev/null | head -20
-```
-
-**Stage 2 — Understanding:** For each match, determine the relationship.
-
-| Relationship | Description | Action |
-|-------------|-------------|--------|
-| **Calls** this code | Another module invokes the function you're changing | Verify caller expectations still hold |
-| **Called by** this code | The function you're changing depends on this | Ensure dependency contract is stable |
-| **Shares state** | Uses the same data store, config, or global | Check for race conditions or stale reads |
-| **Tests** this code | Existing test coverage | Note which tests to update |
-
-**Stage 3 — Identification:** Classify each impacted file.
-
-| Impact Level | Definition | Action |
-|-------------|------------|--------|
-| **Direct** | File you must modify | Include in implementation plan |
-| **Indirect** | File that imports/uses your changed code | Verify no breakage after implementation |
-| **Unaffected** | File with keyword match but no real dependency | Ignore |
-
----
+1. **Discovery** — grep for related functions/classes/constants in src/ and tests/
+2. **Understanding** — classify each match: Calls/Called-by/Shares-state/Tests
+3. **Identification** — label files: Direct (must modify) / Indirect (verify) / Unaffected (ignore)
 
 #### 0d. Duplication Check (Rule of Three)
-
-Evaluate whether similar functionality already exists using the grep results from Stage 1.
-
-| Occurrence | Guideline | Action |
-|-----------|-----------|--------|
-| **1st** (no prior) | New code is fine | Implement inline as planned |
-| **2nd** (1 prior match) | Note the duplication, don't consolidate yet | Implement, add a `// NOTE: similar to <path>:<line>` comment |
-| **3rd+** (2+ prior matches) | Must consolidate | Extract shared logic to a common location before implementing |
-
-**When NOT to consolidate** (even at 3+):
-- The similar code is in a different bounded context (e.g., auth vs. billing)
-- Consolidation would create coupling between unrelated modules
-- The similarity is superficial (same shape, different semantics)
-
-**If high duplication detected (3+ real matches, same semantics):**
-```json
-{
-  "signal": "IMPLEMENTATION_BLOCKED",
-  "reason": "Similar function already exists",
-  "blocker_type": "duplication_detected",
-  "details": [
-    "Existing: src/utils/hash.ts:23 - hashPassword()",
-    "Task asks to implement password hashing in auth service"
-  ],
-  "suggested_resolution": "Import and reuse existing hashPassword() from src/utils/hash.ts"
-}
-```
+1st occurrence → implement inline. 2nd → note similarity. 3rd+ → must consolidate (extract shared logic). Exception: different bounded contexts or superficial similarity. If 3+ real matches with same semantics → emit `IMPLEMENTATION_BLOCKED` with `blocker_type: "duplication_detected"`.
 
 ---
 
 ### 1. Understand the Task
 
-Before writing any code:
-- Read the task from input JSON (already provided - don't re-read)
-- Identify what to build from `task.objective` and `task.acceptance_criteria`
-- Identify test file from `task.test_file`
-- Check `task.traces_to` for spec references
-- **Use `task.context_refs` for JIT context loading** — the task-decomposer provides file paths, section names, and grep patterns instead of stale embedded excerpts. Load the actual current code at runtime:
-  1. Read files from `context_refs.interface_locations` (targeted section reads, not full files)
-  2. Check `context_refs.pattern_files` for implementation patterns to follow
-  3. Run `context_refs.grep_patterns` to discover related code
-  4. Read `context_refs.constraints_section` for constraints and non-scope
+Use `task.context_refs` for JIT context loading:
+1. Read `context_refs.interface_locations` (targeted section reads, not full files)
+2. Check `context_refs.pattern_files` (signatures only: `grep -A 5 "function\|class\|export"`)
+3. Run `context_refs.grep_patterns` to discover related code
+4. Read `context_refs.constraints_section` for constraints
 
-**File Reading Strategy (JIT):**
-
-| Need | Approach |
-|------|----------|
-| Understand interfaces/types | Read from `task.context_refs.interface_locations` (e.g., `grep -A 20 "interface User" src/models/user.ts`) |
-| Find code patterns | Read `task.context_refs.pattern_files` (signatures only: `grep -A 5 "function\|class\|export"`) |
-| Discover related code | Run `task.context_refs.grep_patterns` against `src/` |
-| Know constraints/non-scope | Read `task.context_refs.constraints_section` from spec docs |
-| Find import patterns | `head -30 src/similar-file.ts` |
-| Check test patterns | `head -50 tests/existing.test.ts` |
-| Full file context | Only when modifying that specific file |
-
-**Avoid:**
-- Reading entire directories
-- Reading files you won't modify
-- Reading full spec files — use the section references from `context_refs`
-- Re-reading files already in context
+**Avoid:** reading entire directories, files you won't modify, full spec files, or re-reading files already in context.
 
 ### 2. Read Reference Docs (Targeted Extraction)
 
-**Do NOT read entire spec files.** Extract only relevant sections to stay within context budget.
-
-```bash
-# Extract only the section relevant to this task
-# Use task.traces_to to find relevant sections
-
-# For TECHNICAL_DESIGN.md - find data model or API section
-grep -A 50 "## Data Model" "$SPEC_PATH/TECHNICAL_DESIGN.md" | head -60
-
-# For ADR.md - find specific decision
-grep -A 20 "## Decision" "$SPEC_PATH/ADR.md"
-```
-
-**Targeted extraction by task type:**
-
-| Task Type | Extract From TECHNICAL_DESIGN |
-|-----------|------------------------------|
-| create_model | "## Data Model" section only |
-| add_endpoint | "## API Contracts" section only |
-| create_service | "## Components" + relevant model |
-| add_validation | "## Data Model" constraints |
-| bug_fix | Component where bug exists |
-
-**If task has `traces_to.adr_decisions`:**
-```bash
-# Extract only the referenced ADR decision
-grep -A 30 "ADR-001" "$SPEC_PATH/ADR.md"
-```
-
-**Note:** Spec documents are stored in `$HOME/.claude/homerun/` (centralized storage). Always use the absolute paths from `spec_paths` in the input JSON.
+Extract only relevant spec sections via grep. By task type: create_model → "## Data Model", add_endpoint → "## API Contracts", create_service → "## Components", bug_fix → component section. If `traces_to.adr_decisions` exists → grep that specific decision. Use absolute paths from `spec_paths`.
 
 ### 3. Apply Methodology
 
-Follow the methodology specified in the input JSON (default: `tdd`).
+#### TDD (default): RED → GREEN → REFACTOR → REPEAT per AC
+- Write test BEFORE implementation. Each test must initially FAIL.
+- Simple tasks (add_field, etc.) may use `direct` methodology instead.
 
-#### If methodology is `tdd` (default):
+#### Direct: Implement → verify. For config/docs with `test_file: null`.
 
-Follow the TDD cycle strictly:
-
-```
-RED    -> Write a failing test for ONE acceptance criterion
-GREEN  -> Write minimal code to make the test pass
-REFACTOR -> Clean up while keeping tests green
-REPEAT -> Move to next acceptance criterion
-```
-
-Key principles:
-- Write the test BEFORE the implementation code
-- Each test should initially FAIL (proving it tests something real)
-- Write only enough code to pass the current test
-- Refactor only when tests are green
-
-**Methodology by Task Complexity:**
-
-For **simple tasks** (add_field, add_method, add_validation):
-- These are straightforward enough to use `methodology: "direct"` with tests
-- Write implementation, then write tests to verify
-- This is NOT TDD, but is appropriate for mechanical changes
-- The team-lead should assign `methodology: "direct"` for these task types
-
-For **complex tasks** (create_service, bug_fix, create_model):
-- Use full TDD cycle: RED → GREEN → REFACTOR per criterion
-- Apply test output masking (see below)
-
-**Test Output Masking:**
-
-Test output can consume 5-10K tokens per run. Apply masking:
-
-```bash
-# Run tests with minimal output
-npm test -- --reporter=dot 2>&1 | tail -30
-
-# Or capture and summarize (use worktree-local temp to avoid cross-session collisions)
-TEST_OUT=$(mktemp)
-npm test 2>&1 | tee "$TEST_OUT"
-echo "Tests: $(grep -c 'PASS\|FAIL' "$TEST_OUT") total"
-grep -A 2 'FAIL' "$TEST_OUT" | head -20  # First failure only
-rm -f "$TEST_OUT"
-```
-
-**What to keep in context:**
-- Pass/fail summary (1 line)
-- First failure message + stack trace (10-20 lines)
-- Path to full output if needed later
-
-**What to discard:**
-- Passing test details
-- Duplicate failure messages
-- Coverage reports (unless specifically needed)
-- Watch mode output
-
-#### If methodology is `direct`:
-
-For config-only or documentation tasks with no testable behavior:
-- Implement the change directly
-- Verify the change works as expected
-- No test required (task should have `test_file: null`)
+**Test output masking** (saves 5-10K tokens/run): `npm test -- --reporter=dot 2>&1 | tail -30`. Keep: pass/fail summary + first failure. Discard: passing details, duplicates, coverage reports.
 
 ### 4. Address Rejection Feedback
 
-If this is a retry after rejection:
-- Read the rejection feedback carefully
-- Fix the EXACT issues identified first
-- Do not introduce new features until rejection issues are resolved
-- Verify each rejection point is addressed before proceeding
+On retry: fix EXACT issues from rejection first. No new features until all rejection points resolved.
 
 ### 5. Commit
 
-Once all acceptance criteria pass:
-- Stage changed files: `git add <files>`
-- Commit with conventional format: `feat(<feature>): <task title>`
-- Example: `feat(auth): implement user login endpoint`
+Stage and commit: `feat(<feature>): <task title>`
 
 ### 5.5. Mutation Test Verification
 
-**Task-type gating:** Only run this step for high-risk task types: `bug_fix` and `create_service`. These are the task types where tautological tests cause the most damage. Skip for all other task types.
+**Only for `bug_fix` and `create_service` tasks.** Skip all other types.
 
-This step catches tautological tests — tests that pass regardless of whether the implementation exists. A test that passes when implementation code is removed provides false confidence.
-
-**Procedure:**
-
-1. **Identify the critical implementation line** — the single line that makes the core acceptance criterion work (e.g., the actual validation logic, the service call, the database query)
-
-2. **Mutate** — Comment out that line:
-   ```bash
-   # Save original, comment out the critical line
-   sed -i "${LINE_NUM}s/^/\/\/ MUTATION: /" "$IMPL_FILE"
-   ```
-
-3. **Re-run the relevant test:**
-   ```bash
-   npm test -- --testPathPattern="$TEST_FILE" 2>&1 | tail -10
-   MUTATION_EXIT=$?
-   ```
-
-4. **Evaluate result:**
-   - If test **FAILS** (expected) → Mutation caught. Test is valid. Restore the line and proceed to Step 6.
-   - If test **PASSES** (bad) → Test is tautological. Restore the line and emit:
-     ```json
-     {
-       "signal": "IMPLEMENTATION_BLOCKED",
-       "reason": "Test passes without implementation — tautological test detected",
-       "blocker_type": "tautological_test",
-       "details": [
-         "File: ${IMPL_FILE}:${LINE_NUM}",
-         "Test: ${TEST_FILE}",
-         "The test passes even when the critical implementation line is commented out"
-       ],
-       "suggested_resolution": "Strengthen test assertions to verify actual behavior, not just function existence. Tests must fail when the critical implementation is removed."
-     }
-     ```
-
-5. **Restore original:**
-   ```bash
-   # Always restore, whether mutation was caught or not
-   sed -i "${LINE_NUM}s/^\/\/ MUTATION: //" "$IMPL_FILE"
-   ```
-
-**Scope limit:** Only mutate ONE line for ONE acceptance criterion (the most critical one). This is a quick sanity check, not full mutation testing.
+Catches tautological tests. Procedure: comment out one critical implementation line → re-run test → if test still passes, emit `IMPLEMENTATION_BLOCKED` with `blocker_type: "tautological_test"`. Always restore the line. Scope: ONE line, ONE AC (the most critical).
 
 ### 5.6. Self-Review Checklist
 
-Before signaling completion, run these inline checks to catch issues early and avoid wasting reviewer tokens.
+Run before signaling completion:
 
-**1. Placeholder scan** — grep changed files for leftover debug artifacts:
+1. **Placeholder scan** — grep changed files for TODO/FIXME/console.log/debugger and 3+ consecutive commented lines
+2. **Scope check** — `git diff --name-only HEAD~1` — flag unexpected files not in context_refs
+3. **AC coverage** — must_test ACs have dedicated tests, verify_only in consolidated tests, structural covered by types/lint
+4. **Hard gates** — run tests, tsc --noEmit, eslint; capture exit codes
 
-```bash
-cd "$WORKTREE_PATH"
-grep -rn "TODO\|FIXME\|console\.log\|debugger" ${FILES_CHANGED[@]} | grep -v "node_modules" | head -20
-# Also check for commented-out code blocks (3+ consecutive commented lines)
-grep -n "^[[:space:]]*//" ${FILES_CHANGED[@]} | awk -F: '{f=$1; n=$2} prev_f==f && n==prev_n+1 {count++} prev_f!=f || n!=prev_n+1 {if(count>=3) print prev_f":"(prev_n-count)"-"prev_n" ("count+1" consecutive commented lines)"; count=0} {prev_f=f; prev_n=n}'
-```
-
-**2. Scope check** — verify only expected files were changed:
-
-```bash
-# Compare git changes against task's expected file list
-CHANGED=$(git diff --name-only HEAD~1)
-echo "Files changed: $CHANGED"
-# Flag any file not mentioned in the task's context_refs or acceptance_criteria
-```
-
-If unexpected files were modified, verify they are necessary (e.g., shared types, imports). If not, revert them before proceeding.
-
-**3. AC coverage check** — for each acceptance criterion, confirm there is a corresponding test:
-
-For every `must_test` AC, verify a test exists that exercises it. For `verify_only` ACs, confirm coverage in a consolidated test. For `structural` ACs, confirm types/lint would catch violations.
-
-**4. Hard gate results** — run tests, types, and lint; capture exit codes:
-
-```bash
-cd "$WORKTREE_PATH"
-
-npm test 2>&1 | tail -5
-TEST_EXIT=$?
-
-npx tsc --noEmit 2>&1 | tail -5
-TYPE_EXIT=$?
-
-npx eslint --quiet ${FILES_CHANGED[@]} 2>&1 | tail -5
-LINT_EXIT=$?
-
-echo "hard_gate_results: tests=$TEST_EXIT types=$TYPE_EXIT lint=$LINT_EXIT"
-```
-
-**Decision:**
-
-- If **all checks pass** (no placeholders, no scope creep, all ACs covered, all exit codes 0): proceed to Step 6 and emit `IMPLEMENTATION_COMPLETE` with `hard_gate_results`.
-- If **any check fails**: emit `NEEDS_REWORK` instead, with specific findings. Fix the issues and re-run the self-review.
+All pass → `IMPLEMENTATION_COMPLETE` with `hard_gate_results`. Any fail → `NEEDS_REWORK` with findings.
 
 ### 6. Signal Completion
 
-Output the completion signal in **JSON format** (required for team-lead parsing).
+Output JSON signal wrapped in a ```json code block.
 
 ---
 
-## Output Schema (JSON)
+## Output Signals
 
-All output MUST be valid JSON wrapped in a code block with language `json`.
+All output MUST be valid JSON in a ```json code block. Four possible signals:
 
-### Success: IMPLEMENTATION_COMPLETE
+### IMPLEMENTATION_COMPLETE
+Required fields: `signal`, `files_changed`, `test_file`, `commit_hash`, `hard_gate_results` ({tests, types, lint} exit codes), `verification_level` (L1|L2|L3), `verification_attempted` (array), `acceptance_criteria_met` (array of {criterion, implementation_file, test_location} with file:line format).
 
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "files_changed", "test_file", "commit_hash", "acceptance_criteria_met", "verification_level", "verification_attempted", "hard_gate_results"],
-  "properties": {
-    "signal": { "const": "IMPLEMENTATION_COMPLETE" },
-    "files_changed": { "type": "array", "items": { "type": "string" } },
-    "test_file": { "type": "string" },
-    "commit_hash": { "type": "string", "pattern": "^[a-f0-9]{7,40}$" },
-    "hard_gate_results": {
-      "type": "object",
-      "required": ["tests", "types", "lint"],
-      "properties": {
-        "tests": { "type": "integer", "description": "Exit code from test runner (0 = pass)" },
-        "types": { "type": "integer", "description": "Exit code from type checker (0 = pass)" },
-        "lint": { "type": "integer", "description": "Exit code from linter (0 = pass)" }
-      }
-    },
-    "verification_level": { "type": "string", "enum": ["L1", "L2", "L3"], "description": "Highest verification level achieved" },
-    "verification_attempted": { "type": "array", "items": { "type": "string", "enum": ["L1", "L2", "L3"] }, "description": "All verification levels attempted, in order" },
-    "verification_details": { "type": "string", "description": "What was attempted and why higher levels were not achieved (required if verification_level is L3)" },
-    "acceptance_criteria_met": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["criterion", "implementation_file", "test_location"],
-        "properties": {
-          "criterion": { "type": "string", "description": "AC ID (e.g., AC-001)" },
-          "implementation_file": { "type": "string", "description": "Path with line: src/feature.ts:45" },
-          "test_location": { "type": "string", "description": "Path with line: tests/feature.test.ts:23" }
-        }
-      }
-    }
-  }
-}
-```
+Include `verification_details` if L3-only (explain why L1/L2 impossible). If any AC cannot be addressed → use IMPLEMENTATION_BLOCKED instead. Never omit criteria silently.
 
-**Example:**
+### IMPLEMENTATION_BLOCKED
+Required: `signal`, `reason`, `blocker_type` (missing_dependency|unclear_requirements|technical_constraint|test_failure|tautological_test|duplication_detected), `suggested_resolution`. Optional: `details[]`.
 
-```json
-{
-  "signal": "IMPLEMENTATION_COMPLETE",
-  "files_changed": ["src/models/user.ts", "src/services/auth.ts"],
-  "test_file": "tests/services/auth.test.ts",
-  "commit_hash": "abc1234",
-  "hard_gate_results": { "tests": 0, "types": 0, "lint": 0 },
-  "verification_level": "L2",
-  "verification_attempted": ["L1", "L2"],
-  "verification_details": "L1 attempted — no dev server available in worktree. L2 achieved — all acceptance criteria have passing unit tests.",
-  "acceptance_criteria_met": [
-    {
-      "criterion": "AC-001",
-      "implementation_file": "src/services/auth.ts:45",
-      "test_location": "tests/services/auth.test.ts:12"
-    },
-    {
-      "criterion": "AC-002",
-      "implementation_file": "src/services/auth.ts:67",
-      "test_location": "tests/services/auth.test.ts:34"
-    }
-  ]
-}
-```
+### NEEDS_REWORK
+Self-review failed. Required: `signal`, `findings[]` ({check, description, files}), `hard_gate_results`. Team-lead re-dispatches without reviewer.
 
-**IMPORTANT:** If any acceptance criterion cannot be addressed, return `IMPLEMENTATION_BLOCKED` with reason. Do NOT omit criteria silently.
-```
+### VALIDATION_ERROR
+Required: `signal`, `error_type` (invalid_input|semantic_error), `errors[]` ({path, message, expected, received}).
 
-### Blocked: IMPLEMENTATION_BLOCKED
+## Red Flags — STOP
 
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "reason", "blocker_type", "suggested_resolution"],
-  "properties": {
-    "signal": { "const": "IMPLEMENTATION_BLOCKED" },
-    "reason": { "type": "string" },
-    "blocker_type": { "enum": ["missing_dependency", "unclear_requirements", "technical_constraint", "test_failure", "tautological_test", "duplication_detected"] },
-    "details": { "type": "array", "items": { "type": "string" } },
-    "suggested_resolution": { "type": "string" }
-  }
-}
-```
+**TDD:** No code before test. Test passes immediately → rewrite. Never skip ACs. Never modify code to make a failing test pass.
+**All:** Stay within task scope. No unrelated changes.
 
-**Example:**
+## Test Granularity
 
-```json
-{
-  "signal": "IMPLEMENTATION_BLOCKED",
-  "reason": "Cannot find the User model referenced in TECHNICAL_DESIGN.md",
-  "blocker_type": "missing_dependency",
-  "details": [
-    "Task 001 should have created src/models/user.ts",
-    "File does not exist in the worktree"
-  ],
-  "suggested_resolution": "Run task 001 first or verify task ordering"
-}
-```
+Test observable behavior only (return values, side effects, error responses, state changes). Do NOT test private methods, internal state, or call order. Mock external boundaries only (DB, HTTP, filesystem). If mocking 3+ internal modules → design is too coupled.
 
-**Blocker Types:**
-- `missing_dependency` - Required code/file doesn't exist
-- `unclear_requirements` - Acceptance criteria are ambiguous
-- `technical_constraint` - Cannot implement as specified (e.g., API limitation)
-- `test_failure` - Tests fail and cannot be fixed within scope
+## Context Budget: < 20K tokens
 
-### Self-Review Failed: NEEDS_REWORK
-
-Emitted when the self-review checklist (Step 5.6) finds issues. The implementer should fix the issues and re-run the self-review before signaling completion. If dispatched by the team-lead, this signal is returned instead of IMPLEMENTATION_COMPLETE so the team-lead can re-dispatch without involving a reviewer.
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "findings", "hard_gate_results"],
-  "properties": {
-    "signal": { "const": "NEEDS_REWORK" },
-    "findings": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["check", "description"],
-        "properties": {
-          "check": { "enum": ["placeholder_scan", "scope_check", "ac_coverage", "hard_gate"] },
-          "description": { "type": "string" },
-          "files": { "type": "array", "items": { "type": "string" } }
-        }
-      }
-    },
-    "hard_gate_results": {
-      "type": "object",
-      "properties": {
-        "tests": { "type": "integer" },
-        "types": { "type": "integer" },
-        "lint": { "type": "integer" }
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "signal": "NEEDS_REWORK",
-  "findings": [
-    {
-      "check": "placeholder_scan",
-      "description": "Found console.log in src/services/auth.ts:34",
-      "files": ["src/services/auth.ts"]
-    },
-    {
-      "check": "hard_gate",
-      "description": "Lint failed with 2 errors in src/services/auth.ts",
-      "files": ["src/services/auth.ts"]
-    }
-  ],
-  "hard_gate_results": { "tests": 0, "types": 0, "lint": 1 }
-}
-```
-
-### Validation Error: VALIDATION_ERROR
-
-Return this if input validation fails:
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "error_type", "errors"],
-  "properties": {
-    "signal": { "const": "VALIDATION_ERROR" },
-    "error_type": { "enum": ["invalid_input", "semantic_error"] },
-    "errors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["path", "message"],
-        "properties": {
-          "path": { "type": "string", "description": "JSON path to invalid field, e.g., $.task.id" },
-          "message": { "type": "string" },
-          "expected": { "type": "string" },
-          "received": { "type": "string" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "signal": "VALIDATION_ERROR",
-  "error_type": "invalid_input",
-  "errors": [
-    {
-      "path": "$.task.acceptance_criteria",
-      "message": "acceptance_criteria array is empty",
-      "expected": "non-empty array",
-      "received": "[]"
-    }
-  ]
-}
-```
-
-## Red Flags - STOP
-
-If you find yourself in any of these situations, STOP and correct course:
-
-**For TDD methodology:**
-- **About to write code before test** - You must write the failing test first
-- **Test passes immediately** - The test is not testing new behavior; rewrite it
-- **Skipping acceptance criterion** - Every criterion needs a corresponding test
-- **"I'll add tests later"** - This violates TDD; tests come first, always
-- **Modifying code to make a test pass that should fail** - Tests drive implementation, not the reverse
-- **Testing implementation details** - Tests must verify observable behavior, not internal state (see Test Granularity below)
-
-**For all methodologies:**
-- **Implementing beyond the task scope** - Stick to the assigned task only
-
-## Test Granularity: Observable Behavior Only
-
-Tests must verify **what the code does**, not **how it does it**. A test that breaks when you refactor internals (without changing behavior) is a bad test.
-
-**MUST test (observable behavior):**
-- Public API return values and side effects
-- Error responses and exception types
-- User-visible state changes (DB writes, UI updates, HTTP responses)
-- Contract compliance (response shapes, status codes)
-
-**MUST NOT test (implementation details):**
-- Private methods or internal helper functions
-- Internal state or intermediate variables
-- Call order between internal components
-- Specific implementation patterns (e.g., "uses a for-loop")
-
-**Mocking rules:**
-- Mock external boundaries only (databases, HTTP clients, file system, third-party APIs)
-- Do NOT mock internal modules — if you need to mock an internal, the design is too coupled
-- Use real implementations for in-process code whenever feasible
-
-| Test Smell | Problem | Fix |
-|------------|---------|-----|
-| `expect(spy).toHaveBeenCalledWith(...)` on internal function | Tests implementation, not behavior | Assert on the output/side-effect instead |
-| Mocking 3+ internal modules | Test is coupled to implementation | Use real implementations or integration test |
-| Test breaks after refactor with no behavior change | Testing internals | Rewrite to assert on observable outcomes |
-| `expect(instance.privateField).toBe(...)` | Testing internal state | Assert through public API only |
-
-## Context Budget
-
-**Target: < 20K tokens per implementation**
-
-| Component | Budget | Strategy |
-|-----------|--------|----------|
-| Pre-implementation analysis (0a-0d) | ~2.5K | Strategy + grep output + brief notes, no full reads |
-| Task input | ~1K | Already minimal |
-| Spec extraction | ~2K | Targeted grep, not full reads |
-| Existing code reads | ~3K | Signatures only, expand as needed |
-| Test output (per run) | ~0.5K | Masked: summary + first failure |
-| Implementation | ~4K | The actual work |
-| Commit/output | ~0.5K | Minimal |
-| **Buffer** | ~7K | For iterations and edge cases |
-
-**If approaching 20K:**
-1. Stop reading new files
-2. Summarize what you know
-3. Complete with current context or signal BLOCKED
-
----
+Pre-impl ~2.5K | Task input ~1K | Spec extraction ~2K | Code reads ~3K | Test output ~0.5K | Implementation ~4K | Buffer ~7K. If approaching 20K: stop reading, summarize, complete or signal BLOCKED.
 
 ## Verification Levels
 
-Every completed task MUST attempt verification levels in strict order: L1 first, then L2, then L3. You may only fall back to a lower level when the higher level is genuinely impossible for this task — not merely inconvenient.
-
-| Level | Name | What It Proves | How to Verify |
-|-------|------|---------------|---------------|
-| **L1** | Functional Operation | User-visible feature works end-to-end | Run the feature manually or via integration test |
-| **L2** | Test Operation | New tests added and passing | `npm test` (or equivalent) shows green for new tests |
-| **L3** | Build Success | Code compiles without errors | `npm run build` (or equivalent) exits 0 |
-
-**Required attempt order:**
-1. **Attempt L1 first.** Only skip if genuinely infeasible (e.g., no UI to exercise, no running server, no integration test harness).
-2. **Attempt L2 next.** Only skip if no test runner is available or configured.
-3. **L3 is the absolute minimum.** If L3 is the only level achieved, you MUST include a brief explanation of why L1 and L2 were not possible.
-
-**Claiming L3-only without justification is a review finding.** The reviewer will flag implementations that report only L3 without explaining why higher levels were impossible.
-
-Include the verification level and attempted levels in the completion signal:
-```json
-{
-  "signal": "IMPLEMENTATION_COMPLETE",
-  "verification_level": "L2",
-  "verification_attempted": ["L1", "L2"],
-  "verification_details": "L1 attempted — no dev server in worktree, could not exercise endpoint. L2 achieved — all 3 acceptance criteria have passing unit tests."
-}
-```
-
-If only L3 was achieved:
-```json
-{
-  "signal": "IMPLEMENTATION_COMPLETE",
-  "verification_level": "L3",
-  "verification_attempted": ["L1", "L2", "L3"],
-  "verification_details": "L1 not possible — config-only change with no UI surface. L2 not possible — no test runner configured in project. L3 achieved — build exits 0."
-}
-```
+Attempt in order: **L1** (feature works e2e) → **L2** (tests pass) → **L3** (builds clean). Only fall back when higher level is genuinely impossible. L3-only without justification is a review finding.
 
 ---
 
 ## Exit Criteria
 
-Before signaling completion, verify this checklist:
-
-**For TDD methodology:**
-- [ ] All `must_test` ACs have dedicated passing tests
-- [ ] `verify_only` ACs confirmed in integration/consolidated tests
-- [ ] `structural` ACs confirmed by types/lint passing
-- [ ] Tests were written BEFORE implementation code
-
-**For direct methodology:**
-- [ ] All acceptance criteria are implemented
-- [ ] Change verified to work as expected
-
-**For all methodologies:**
-- [ ] Verification levels attempted in order (L1 > L2 > L3), all attempts reported in `verification_attempted`
-- [ ] If only L3 achieved, `verification_details` explains why L1 and L2 were not possible
-- [ ] Code is committed with proper message format: `feat(<feature>): <task title>`
-- [ ] `IMPLEMENTATION_COMPLETE` signal sent with files, test file, commit hash, and verification level
-- [ ] No rejection feedback items remain unaddressed (if retry)
-- [ ] Context stayed within budget (< 20K tokens)
+- [ ] All ACs addressed (must_test → dedicated tests, verify_only → integration tests, structural → types/lint)
+- [ ] TDD: tests written before implementation
+- [ ] Verification attempted L1 → L2 → L3; L3-only justified
+- [ ] Committed with `feat(<feature>): <task title>`
+- [ ] Signal emitted with files, test file, commit hash, verification level
+- [ ] No unaddressed rejection feedback (if retry)
+- [ ] Context < 20K tokens

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -37,27 +37,7 @@ Scan every AC for placeholder language. Reject: "TBD/TODO", "add appropriate err
 
 ### 0. Pre-Implementation Analysis
 
-**Skip for haiku tasks** (add_field, add_method, add_validation, rename_refactor, add_test, add_config, add_endpoint) → jump to Step 1. **Sonnet/opus tasks only.** Budget: ~2.5K tokens.
-
-#### 0a. Strategy Selection
-Pick one: vertical-slice | horizontal-layer | outside-in | inside-out | risk-first. Document rationale in 2-3 sentences. Risk-first if uncertain, horizontal if extending patterns, vertical-slice if greenfield.
-
-#### 0b. Metacognitive Questions
-3-5 self-interrogation questions by task type. Answer briefly. "I don't know" → investigate via targeted grep before coding.
-
-- create_model/add_field: existing references? migrations? serialization breaks?
-- create_service/add_method: call chain? consumers? error states?
-- add_endpoint: middleware? auth? response contract?
-- bug_fix: reproducible? root cause vs symptom? regression test?
-- create_middleware: execution order? downstream data? failure modes?
-
-#### 0c. Impact Analysis (3-Stage)
-1. **Discovery** — grep for related functions/classes/constants in src/ and tests/
-2. **Understanding** — classify each match: Calls/Called-by/Shares-state/Tests
-3. **Identification** — label files: Direct (must modify) / Indirect (verify) / Unaffected (ignore)
-
-#### 0d. Duplication Check (Rule of Three)
-1st occurrence → implement inline. 2nd → note similarity. 3rd+ → must consolidate (extract shared logic). Exception: different bounded contexts or superficial similarity. If 3+ real matches with same semantics → emit `IMPLEMENTATION_BLOCKED` with `blocker_type: "duplication_detected"`.
+**Skip for haiku tasks** → jump to Step 1. **Sonnet/opus tasks only:** Read `skills/implement/pre-implementation-analysis.md` and complete steps 0a-0d (strategy, metacognitive questions, impact analysis, duplication check). Budget: ~2.5K tokens.
 
 ---
 
@@ -79,9 +59,10 @@ Extract only relevant spec sections via grep. By task type: create_model → "##
 
 #### TDD (default): RED → GREEN → REFACTOR → REPEAT per AC
 - Write test BEFORE implementation. Each test must initially FAIL.
-- Simple tasks (add_field, etc.) may use `direct` methodology instead.
+- For full TDD guide and anti-patterns, read `skills/test-driven-development/SKILL.md`
+- Haiku tasks use `direct` methodology instead — no TDD ceremony needed.
 
-#### Direct: Implement → verify. For config/docs with `test_file: null`.
+#### Direct: Implement → verify. For haiku tasks and config/docs with `test_file: null`.
 
 **Test output masking** (saves 5-10K tokens/run): `npm test -- --reporter=dot 2>&1 | tail -30`. Keep: pass/fail summary + first failure. Discard: passing details, duplicates, coverage reports.
 

--- a/skills/implement/pre-implementation-analysis.md
+++ b/skills/implement/pre-implementation-analysis.md
@@ -1,0 +1,62 @@
+# Pre-Implementation Analysis (Step 0)
+
+**For sonnet/opus tasks only.** Haiku tasks skip this entirely. Budget: ~2.5K tokens.
+
+## 0a. Strategy Selection
+
+Pick one strategy and document rationale in 2-3 sentences:
+
+| Strategy | When to Use |
+|----------|-------------|
+| **Vertical slice** | Greenfield — prove e2e path works |
+| **Horizontal layer** | Extending existing patterns |
+| **Outside-in** | Start from API surface, work inward |
+| **Inside-out** | Start from data, work outward |
+| **Risk-first** | Uncertain — validate the riskiest part early |
+
+## 0b. Metacognitive Questions
+
+Generate 3-5 self-interrogation questions by task type. Answer briefly. "I don't know" → investigate via targeted grep before coding.
+
+- **create_model/add_field:** existing references? migrations? serialization breaks?
+- **create_service/add_method:** call chain? consumers? error states?
+- **add_endpoint:** middleware? auth? response contract?
+- **bug_fix:** reproducible? root cause vs symptom? regression test?
+- **create_middleware:** execution order? downstream data? failure modes?
+- **architectural:** blast radius? what breaks if wrong? reversible?
+
+## 0c. Impact Analysis (3-Stage)
+
+1. **Discovery** — grep for related functions/classes/constants in src/ and tests/
+   ```bash
+   grep -rn "function.*${KEYWORD}\|class.*${KEYWORD}" src/ --include="*.ts" --include="*.js" | head -20
+   grep -rn "${KEYWORD}" tests/ --include="*.test.*" | head -10
+   ```
+
+2. **Understanding** — classify each match:
+   - **Calls** this code → verify caller expectations hold
+   - **Called by** this code → ensure dependency contract stable
+   - **Shares state** → check for race conditions
+   - **Tests** this code → note which tests to update
+
+3. **Identification** — label files:
+   - **Direct** (must modify) → include in plan
+   - **Indirect** (imports changed code) → verify after
+   - **Unaffected** (keyword match, no dependency) → ignore
+
+## 0d. Duplication Check (Rule of Three)
+
+1st occurrence → implement inline. 2nd → note similarity (`// NOTE: similar to <path>:<line>`). 3rd+ → must consolidate (extract shared logic).
+
+**When NOT to consolidate** (even at 3+): different bounded contexts, coupling risk, superficial similarity.
+
+**If 3+ real matches with same semantics:**
+```json
+{
+  "signal": "IMPLEMENTATION_BLOCKED",
+  "blocker_type": "duplication_detected",
+  "reason": "Similar function already exists",
+  "details": ["Existing: <path>:<line> — <function>"],
+  "suggested_resolution": "Import and reuse existing implementation"
+}
+```

--- a/skills/quality-check/SKILL.md
+++ b/skills/quality-check/SKILL.md
@@ -7,21 +7,13 @@ color: teal
 
 # Quality Check Skill
 
-## Reference Materials
+## References
 
-- Signal contracts: `references/signal-contracts.json`
-- Context patterns: `references/context-engineering.md`
-- Sequential zero-error gate model: `references/quality-gates.md`
+`references/signal-contracts.json` · `references/context-engineering.md` · `references/quality-gates.md`
 
 ## Overview
 
-You are a **quality assurance agent**. Your job: run a structured 5-phase quality pipeline on changed files and fix issues autonomously. This skill complements the `review` skill — review checks spec compliance, quality-check validates code health.
-
-The team-lead can invoke this after review approval or as a standalone gate before completion.
-
-**Model Selection:** Sonnet — quality checks require judgment for fixes but not deep reasoning.
-
-**Context Budget:** Target < 15K tokens.
+5-phase quality pipeline on changed files. Complements review (spec compliance) with code health validation. Invoked after review approval or as standalone gate. **Model: sonnet. Budget: < 15K tokens.**
 
 ---
 
@@ -64,127 +56,23 @@ The team-lead can invoke this after review approval or as a standalone gate befo
 
 ## Process
 
-### Phase 1: Lint & Format (HOOK — handled by `homerun-quality-lint.sh`)
+### Phase 1-2: Lint & Types (HOOKS — zero LLM cost)
 
-**Git hook detection:** Before running, check if a git hook framework (husky, pre-commit, custom) already enforces lint. If so, skip this phase with `"skipped_by_hooks"` status — the git hooks already guarantee lint compliance at commit time.
+Handled by `scripts/homerun-quality-lint.sh` and `scripts/homerun-quality-typecheck.sh`. Skip with `skipped_by_hooks` if git hooks (husky/pre-commit) already enforce. Agent reads exit codes only.
 
-```bash
-# Only skip if hooks are verifiably enforcing lint:
-# - husky: dir exists AND husky in devDependencies AND pre-commit hook is executable
-# - pre-commit: config exists AND .git/hooks/pre-commit links to pre-commit framework
-# - custom: hook is executable and contains lint/format commands
-LINT_STATUS=""
-if [ -d "$WORKTREE_PATH/.husky" ] && [ -x "$WORKTREE_PATH/.husky/pre-commit" ] && grep -q '"husky"' "$WORKTREE_PATH/package.json" 2>/dev/null; then
-  LINT_STATUS="skipped_by_hooks"
-elif [ -f "$WORKTREE_PATH/.pre-commit-config.yaml" ] && [ -x "$WORKTREE_PATH/.git/hooks/pre-commit" ] && grep -q "pre-commit" "$WORKTREE_PATH/.git/hooks/pre-commit" 2>/dev/null; then
-  LINT_STATUS="skipped_by_hooks"
-fi
-# When in doubt, don't skip — better to lint twice than miss a violation
-```
+### Phase 3: Structural Review (LLM — only phase requiring judgment)
 
-**If no git hooks enforce lint:** This phase is handled by the standalone hook script `scripts/homerun-quality-lint.sh`. The hook runs automatically as part of the quality gate pipeline. If running quality-check manually, execute the hook first:
+Review changed files for: unused imports, dead code, debug artifacts (console.log, debugger), naming consistency, file organization. Grep for artifacts first.
 
-```bash
-bash "$PLUGIN_ROOT/scripts/homerun-quality-lint.sh"
-LINT_EXIT=$?
-```
+**Blocking** (fail): debug artifacts, genuine dead code. **Advisory** (pass): naming, organization, benign TODOs.
 
-The quality-checker agent does NOT run lint — it reads the hook's exit code and reports the result.
+### Phase 4: Tests (DETERMINISTIC)
 
-### Phase 2: Type Checking (HOOK — handled by `homerun-quality-typecheck.sh`)
+Run test suite, check exit code. If fail + fix_mode=auto → attempt fix (max 2). Still failing → report unresolved.
 
-**Git hook detection:** Same as Phase 1 — if git hooks already enforce type checking, skip with `"skipped_by_hooks"` status.
+### Phase 5: Final Recheck (DETERMINISTIC)
 
-**If no git hooks enforce types:** This phase is handled by the standalone hook script `scripts/homerun-quality-typecheck.sh`. Execute before quality-check if running manually:
-
-```bash
-bash "$PLUGIN_ROOT/scripts/homerun-quality-typecheck.sh"
-TYPE_EXIT=$?
-```
-
-The quality-checker agent does NOT run type checking — it reads the hook's exit code and reports the result.
-
-### Phase 3: Structural Review (LLM JUDGMENT — this is where you add value)
-
-This is the ONLY phase that requires LLM reasoning. The other phases are deterministic CLI checks.
-
-Review changed files for:
-
-1. **Unused imports** — imports not referenced in the file body
-2. **Dead code** — functions, variables, or classes that are defined but never used
-3. **Debug artifacts** — `console.log`, `debugger`, `TODO`/`FIXME` comments left behind
-4. **Naming consistency** — do new names follow the existing codebase conventions?
-5. **File organization** — are new files in the right directories?
-
-```bash
-cd "$WORKTREE_PATH"
-
-for file in "${FILES[@]}"; do
-  # Quick checks the LLM can interpret
-  if [[ "$file" =~ \.(ts|tsx|js|jsx)$ ]]; then
-    echo "=== $file ==="
-    grep -n "console\.\(log\|debug\|warn\)" "$file" | head -5
-    grep -n "debugger" "$file" | head -5
-    grep -n "TODO\|FIXME\|HACK\|XXX" "$file" | head -5
-  fi
-done
-```
-
-#### Severity Tiers
-
-Classify each structural finding as **blocking** or **advisory**:
-
-**Blocking** (affects verdict):
-- Debug artifacts (`console.log`, `debugger`) — these would reach production
-- Genuine dead code (functions/variables defined but never called anywhere)
-
-**Advisory** (reported but don't block pass):
-- Naming consistency — follows conventions but non-standard
-- File organization — could be better but functional
-- Benign TODO/FIXME — tracked work items, not forgotten debug code
-
-Advisory-only findings result in `pass` (not `fail`). Only blocking findings cause `fail`.
-
-### Phase 4: Tests (DETERMINISTIC — no LLM judgment)
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Run full test suite and check exit code (use mktemp to avoid cross-session collisions)
-if [ -f package.json ]; then
-  TEST_OUT=$(mktemp)
-  npm test 2>&1 | tee "$TEST_OUT"
-  TEST_EXIT=$?
-  echo "Exit code: $TEST_EXIT"
-  grep -A 2 'FAIL' "$TEST_OUT" | head -20
-  rm -f "$TEST_OUT"
-elif [ -f Cargo.toml ]; then
-  cargo test 2>&1 | tail -30
-  TEST_EXIT=$?
-elif [ -f pyproject.toml ]; then
-  pytest 2>&1 | tail -30
-  TEST_EXIT=$?
-fi
-
-# Result: TEST_EXIT == 0 means pass. No LLM analysis needed.
-```
-
-**If tests fail and fix_mode=auto:** Attempt to fix failing tests (max 2 attempts). This requires LLM judgment.
-**If tests still fail after 2 attempts:** Report as unresolved.
-
-### Phase 5: Final Recheck (DETERMINISTIC — no LLM judgment)
-
-After all auto-fixes, re-run deterministic checks to confirm no regressions:
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Re-run phases 1 and 2
-npx tsc --noEmit 2>&1 | grep "error" | wc -l
-npm test 2>&1 | grep -E "Tests:.*failed" || echo "All tests pass"
-```
-
-If new issues introduced by auto-fixes, revert auto-fixes and report as `needs_manual_fix`.
+Re-run phases 1-2 after auto-fixes. New issues from fixes → revert, report `needs_manual_fix`.
 
 ---
 
@@ -307,20 +195,7 @@ When verdict is `fail`:
 
 ## Exit Criteria
 
-- [ ] All 5 phases executed (or skipped with reason)
-- [ ] Auto-fixes applied where possible (if fix_mode=auto)
-- [ ] Recheck confirms no regressions from fixes
-- [ ] Verdict determined
-- [ ] Signal emitted with phase-by-phase results
+- [ ] All 5 phases executed/skipped; auto-fixes applied; recheck passed; verdict + signal emitted
 
----
-
-## Context Budget
-
-| Component | Budget | Strategy |
-|-----------|--------|----------|
-| Input + file reads | ~3K | Changed files only |
-| Phase execution | ~6K | Command output masked (tail -20) |
-| Auto-fixes | ~3K | Targeted changes only |
-| Report | ~1K | Structured output |
-| **Buffer** | ~2K | Retries |
+## Context Budget: ~15K
+Input ~3K | Execution ~6K | Fixes ~3K | Report ~1K | Buffer ~2K

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,522 +7,96 @@ color: blue
 
 # Review Skill
 
-## Reference Materials
+## References
 
-For detailed examples, see `cookbooks/review-feedback-examples.md`.
+`cookbooks/review-feedback-examples.md`
 
 ## Overview
 
-You are a reviewer agent. Your job is to verify that an implementation meets its specification, then approve or reject with specific feedback.
+Reviewer agent. Verify implementation meets specification → approve or reject with specific feedback.
 
-## Input Schema (JSON)
+## Input Schema
 
-The team-lead provides input as a JSON object. **Validate input before proceeding.**
+Validate before proceeding. Required: `task` (id, title, acceptance_criteria with risk_level), `implementation` (commit_hash, files_changed, test_file, verification_level/attempted/details), `spec_paths` (technical_design, adr), `worktree_path`.
 
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["task", "implementation", "spec_paths", "worktree_path"],
-  "properties": {
-    "task": {
-      "type": "object",
-      "required": ["id", "title", "acceptance_criteria"],
-      "properties": {
-        "id": { "type": "string", "pattern": "^[0-9]{3}$" },
-        "title": { "type": "string" },
-        "objective": { "type": "string" },
-        "acceptance_criteria": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["id", "criterion"],
-            "properties": {
-              "id": { "type": "string", "pattern": "^AC-[0-9]{3}$" },
-              "criterion": { "type": "string" },
-              "risk_level": {
-                "type": "string",
-                "enum": ["must_test", "verify_only", "structural"],
-                "default": "must_test",
-                "description": "Test requirement level from task-decomposition. Default to must_test if not set."
-              }
-            }
-          }
-        }
-      }
-    },
-    "implementation": {
-      "type": "object",
-      "required": ["commit_hash", "files_changed", "test_file"],
-      "properties": {
-        "commit_hash": { "type": "string", "pattern": "^[a-f0-9]{7,40}$" },
-        "files_changed": { "type": "array", "items": { "type": "string" } },
-        "test_file": { "type": "string" },
-        "verification_level": { "type": "string", "enum": ["L1", "L2", "L3"], "description": "Highest verification level achieved by implementer" },
-        "verification_attempted": { "type": "array", "items": { "type": "string", "enum": ["L1", "L2", "L3"] }, "description": "All verification levels the implementer attempted" },
-        "verification_details": { "type": "string", "description": "Explanation of verification attempts and why higher levels were not achieved" }
-      }
-    },
-    "spec_paths": {
-      "type": "object",
-      "required": ["technical_design", "adr"],
-      "properties": {
-        "technical_design": { "type": "string" },
-        "adr": { "type": "string" }
-      }
-    },
-    "previous_rejections": {
-      "type": "array",
-      "description": "Feedback from previous review attempts (present on re-reviews)",
-      "items": {
-        "type": "object",
-        "properties": {
-          "attempt": { "type": "integer" },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "criterion": { "type": "string" },
-                "description": { "type": "string" },
-                "severity": { "enum": ["high", "medium", "low"] }
-              }
-            }
-          },
-          "required_fixes": { "type": "array", "items": { "type": "string" } }
-        }
-      }
-    },
-    "worktree_path": { "type": "string" },
-    "skip_hard_gates": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, skip Tier 1 hard gate re-execution. Set by team-lead when implementer's hard_gate_results show all exit codes 0."
-    },
-    "hard_gate_results": {
-      "type": "object",
-      "description": "Cached hard gate exit codes from the implementer's self-review. Present when skip_hard_gates is true.",
-      "properties": {
-        "tests": { "type": "integer" },
-        "types": { "type": "integer" },
-        "lint": { "type": "integer" }
-      }
-    }
-  }
-}
-```
+Optional: `previous_rejections[]` (on re-reviews), `skip_hard_gates` (bool), `hard_gate_results` ({tests, types, lint} exit codes).
 
-### Example Input
-
-```json
-{
-  "task": {
-    "id": "002",
-    "title": "Implement user authentication service",
-    "acceptance_criteria": [
-      {"id": "AC-001", "criterion": "User can log in with valid credentials"},
-      {"id": "AC-002", "criterion": "Invalid credentials return 401 error"}
-    ]
-  },
-  "implementation": {
-    "commit_hash": "abc1234",
-    "files_changed": ["src/services/auth.ts", "src/middleware/auth.ts"],
-    "test_file": "tests/services/auth.test.ts"
-  },
-  "spec_paths": {
-    "technical_design": "/home/user/.claude/homerun/a1b2c3d4/user-auth-e5f6g7h8/TECHNICAL_DESIGN.md",
-    "adr": "/home/user/.claude/homerun/a1b2c3d4/user-auth-e5f6g7h8/ADR.md"
-  },
-  "previous_rejections": [],
-  "worktree_path": "/path/to/worktree"
-}
-```
-
-### Input Validation
-
-**Before any review work, validate the input:**
-
-1. Check all required fields are present
-2. Verify `implementation.commit_hash` is valid (exists in git history)
-3. Verify `implementation.files_changed` are present in the commit
-4. Verify `spec_paths.technical_design` and `spec_paths.adr` files exist
-
-If validation fails, output a `VALIDATION_ERROR` signal (see Output Schema).
+Validation: required fields present, commit_hash exists in git, files_changed in commit, spec files exist. Fail → `VALIDATION_ERROR`.
 
 ## Two-Tier Evaluation Process
 
-### Tier 1: Hard Gate (Deterministic — run FIRST)
+### Tier 1: Hard Gate (Deterministic — FIRST)
 
-**Fast-path skip:** If the input includes `skip_hard_gates: true` and `hard_gate_results` with all exit codes 0, skip Tier 1 entirely and proceed to Tier 2. Log: "Hard gates cached from implementer — tests=0 types=0 lint=0. Skipping Tier 1." Use the cached results in the output `hard_gates` field (map exit code 0 to "pass").
+**Fast-path:** `skip_hard_gates: true` + all exit codes 0 → skip to Tier 2, use cached results. Otherwise run tests, tsc --noEmit, eslint. Any failure → reject immediately (no Tier 2).
 
-If `skip_hard_gates` is false, `hard_gate_results` is missing, or any exit code is non-zero, run Tier 1 normally:
+**Verification level check:** L1/L2 → pass. L3 with valid justification → pass (note as finding). L3 without justification → medium severity finding. Missing fields → treat as L3-unjustified.
+
+### Tier 2: Soft Review (LLM — score-based)
+
+Score 0.0-1.0. **Threshold: >= 0.7 = APPROVE.** 0.9+ = clean, 0.7-0.89 = minor issues (approve), 0.5-0.69 = missing edge case (reject), <0.5 = core issues (reject). Only flag edge cases causing silent wrong output, not explicit errors.
+
+### Diff-Based File Reading (Token Optimization)
+
+**Use `git diff` as the primary review input instead of reading full files.** This dramatically reduces token consumption for tasks touching large files.
 
 ```bash
 cd "$WORKTREE_PATH"
-
-# 1. Tests pass
-npm test 2>&1 | tail -5
-TEST_EXIT=$?
-
-# 2. Types check
-npx tsc --noEmit 2>&1 | tail -5
-TYPE_EXIT=$?
-
-# 3. Lint clean
-npx eslint --quiet "${FILES[@]}" 2>&1 | tail -5
-LINT_EXIT=$?
-
-# Report
-if [ $TEST_EXIT -ne 0 ] || [ $TYPE_EXIT -ne 0 ] || [ $LINT_EXIT -ne 0 ]; then
-  echo "HARD_GATE_FAILED: tests=$TEST_EXIT types=$TYPE_EXIT lint=$LINT_EXIT"
-  # Reject immediately — no LLM judgment needed
-fi
+# Get the diff for the implementation commit
+git diff ${COMMIT_HASH}~1..${COMMIT_HASH} -- ${FILES_CHANGED[@]}
 ```
 
-**4. Verification level check:**
+**Review workflow:**
+1. Read the diff output first — this shows exactly what changed with surrounding context
+2. Only read full files when the diff is insufficient to evaluate an AC (e.g., need to understand broader control flow)
+3. For test files, read the full test file since test structure matters for evaluating coverage
+4. For spec comparison, use targeted grep on spec sections (not full spec reads)
 
-Check the implementer's completion signal for adequate verification:
-
-- If `verification_level` is `L1` or `L2`: pass.
-- If `verification_level` is `L3` and `verification_details` provides a valid justification for why L1/L2 were not possible: pass (but note it as a Tier 2 finding for visibility).
-- If `verification_level` is `L3` with no justification or a weak justification (e.g., "didn't try"): flag as a **medium** severity finding in Tier 2. Do not auto-reject, but the finding will lower the Tier 2 score.
-- If `verification_level` or `verification_attempted` fields are missing from the completion signal: treat as L3-without-justification.
-
-**If any hard gate fails (tests, types, lint):** Reject immediately with the specific error output. Do not proceed to Tier 2. This saves the cost of LLM analysis on obviously broken implementations.
-
-### Tier 2: Soft Review (LLM Judgment — score-based)
-
-Only reached if all hard gates pass. Score 0.0-1.0:
-
-| Score | Meaning | Action |
-|-------|---------|--------|
-| 0.9-1.0 | All criteria met, clean implementation | APPROVE |
-| 0.7-0.89 | All criteria met, minor style/naming issues | APPROVE (not worth a retry cycle) |
-| 0.5-0.69 | Most criteria met, missing edge case or coverage gap | REJECT |
-| 0.0-0.49 | Core criteria unmet, bugs, security issues | REJECT |
-
-**Approval threshold: >= 0.7**
-
-**Edge case calibration:** An edge case worth flagging is one that causes **silent wrong output** — data corruption, incorrect calculations, security bypass. Input that triggers an explicit error (exception, validation failure) is already handled. Don't flag missing null guards unless absence would cause a crash or silent corruption.
+**When to fall back to full file reads:**
+- Diff shows changes to a function signature → read callers to verify no breakage
+- AC requires understanding data flow across multiple functions → read relevant functions
+- Security review requires understanding the full request handling chain
 
 ### Review Checklist (Tier 2)
 
-#### Acceptance Criteria (Required)
+**Acceptance criteria** by risk_level: must_test → implemented + dedicated test + test verifies it | verify_only → implemented + consolidated test | structural → implemented + types/lint confirm.
 
-For EACH acceptance criterion in the task file, check based on `risk_level` (default to `must_test` if `risk_level` is not set):
+**Technical alignment:** matches spec_paths.technical_design patterns, data models, API contracts.
+**Security:** follows spec_paths.adr decisions, no vulnerabilities, sensitive data handled.
 
-| Risk Level | What to Check |
-|---|---|
-| `must_test` | Is it implemented? Does it have a dedicated test? Does the test actually verify the criterion? |
-| `verify_only` | Is it implemented? Is it covered by a consolidated/integration test? |
-| `structural` | Is it implemented? Do types/lint confirm correctness? |
+## Severity Classification
 
-#### Technical Alignment (Required)
+**high:** Fails AC, security flaw, violates ADR → blocks spawning, escalates. **medium:** Missing must_test coverage, unhandled edge case → retry with feedback. **low:** Style/naming → retry with feedback. Overall severity = highest among all issues.
 
-- Implementation matches patterns in `spec_paths.technical_design` (centralized in `$HOME/.claude/homerun/`)
-- Data models match those defined in the design
-- API contracts match the specification
+## Output Signals
 
-#### Security (If Applicable)
+All output: valid JSON in ```json code block.
 
-- Follows security decisions documented in `spec_paths.adr` (centralized in `$HOME/.claude/homerun/`)
-- No obvious vulnerabilities introduced
-- Sensitive data handled appropriately
+### APPROVED
+Required: `signal`, `summary`, `score` (>= 0.7), `hard_gates` ({tests, types, lint}: pass|fail|skipped), `verified[]` ({criterion, description, implementation_file, test_file} with file:line format).
 
-## Severity Classification Rubric
+### REJECTED
+Required: `signal`, `summary`, `score` (< 0.7, omit if hard gate failed), `hard_gates`, `issues[]` ({criterion, description, file, line, severity}), `required_fixes[]`.
 
-When rejecting, assign severity to each issue using this rubric:
+### VALIDATION_ERROR
+Required: `signal`, `error_type` (invalid_input|semantic_error), `errors[]` ({path, message, expected, received}).
 
-| Severity | Criteria | Examples |
-|----------|----------|----------|
-| **high** | Fails acceptance criterion, security flaw, or violates architectural decision from ADR | Wrong logic (off-by-one), missing auth check, SQL injection, diverges from TECHNICAL_DESIGN without reason |
-| **medium** | Missing test coverage for `must_test` AC, unhandled edge case, or non-critical spec deviation | No test for a `must_test` AC, missing null/empty check, inconsistent error format. Missing test for `verify_only`/`structural` ACs is **low**, not medium. |
-| **low** | Style, naming, or non-functional suggestion that doesn't affect correctness | Variable naming, missing JSDoc on internal function, minor formatting |
+## Re-Review Process
 
-**Severity determines team-lead retry behavior:**
-- **high** → Blocks all new task spawning, escalates to user
-- **medium** → Task retried with feedback, other tasks continue
-- **low** → Task retried with feedback, other tasks continue
-
-**When multiple issues exist:** The overall rejection severity is the **highest** severity among all issues. A single high-severity issue makes the entire rejection high-severity.
-
-## Output Schema (JSON)
-
-All output MUST be valid JSON wrapped in a code block with language `json`.
-
-### Approved: APPROVED
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "summary", "score", "hard_gates", "verified"],
-  "properties": {
-    "signal": { "const": "APPROVED" },
-    "summary": { "type": "string" },
-    "score": { "type": "number", "minimum": 0.7, "maximum": 1.0, "description": "Tier 2 quality score (0.0-1.0). Must be >= 0.7 for approval." },
-    "hard_gates": {
-      "type": "object",
-      "properties": {
-        "tests": { "enum": ["pass", "fail", "skipped"] },
-        "types": { "enum": ["pass", "fail", "skipped"] },
-        "lint": { "enum": ["pass", "fail", "skipped"] }
-      }
-    },
-    "verified": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["criterion", "implementation_file", "test_file"],
-        "properties": {
-          "criterion": { "type": "string", "pattern": "^AC-[0-9]{3}$" },
-          "description": { "type": "string" },
-          "implementation_file": { "type": "string", "description": "Path with optional line number: file.ts:45" },
-          "test_file": { "type": "string", "description": "Path with optional line number: test.ts:12" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "signal": "APPROVED",
-  "summary": "User authentication service implemented with password hashing and session management",
-  "score": 0.92,
-  "hard_gates": { "tests": "pass", "types": "pass", "lint": "pass" },
-  "verified": [
-    {
-      "criterion": "AC-001",
-      "description": "User can register with email/password",
-      "implementation_file": "src/services/auth.ts:45",
-      "test_file": "tests/services/auth.test.ts:12"
-    },
-    {
-      "criterion": "AC-002",
-      "description": "Passwords are hashed with bcrypt",
-      "implementation_file": "src/services/auth.ts:67",
-      "test_file": "tests/services/auth.test.ts:34"
-    }
-  ]
-}
-```
-
-### Rejected: REJECTED
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "summary", "score", "hard_gates", "issues", "required_fixes"],
-  "properties": {
-    "signal": { "const": "REJECTED" },
-    "summary": { "type": "string" },
-    "score": { "type": "number", "minimum": 0.0, "maximum": 0.69, "description": "Tier 2 quality score. < 0.7 triggers rejection. Omit if hard gate failed." },
-    "hard_gates": {
-      "type": "object",
-      "properties": {
-        "tests": { "enum": ["pass", "fail", "skipped"] },
-        "types": { "enum": ["pass", "fail", "skipped"] },
-        "lint": { "enum": ["pass", "fail", "skipped"] }
-      }
-    },
-    "issues": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["criterion", "description", "severity"],
-        "properties": {
-          "criterion": { "type": "string" },
-          "description": { "type": "string" },
-          "file": { "type": "string" },
-          "line": { "type": "integer" },
-          "severity": { "enum": ["high", "medium", "low"] }
-        }
-      }
-    },
-    "required_fixes": {
-      "type": "array",
-      "items": { "type": "string" }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "signal": "REJECTED",
-  "summary": "Implementation missing error handling and test coverage for edge cases",
-  "score": 0.55,
-  "hard_gates": { "tests": "pass", "types": "pass", "lint": "pass" },
-  "issues": [
-    {
-      "criterion": "AC-002",
-      "description": "Empty input not validated",
-      "file": "src/validators/user.ts",
-      "line": 23,
-      "severity": "high"
-    },
-    {
-      "criterion": "AC-003",
-      "description": "Missing test for invalid email format",
-      "file": "tests/validators/user.test.ts",
-      "severity": "medium"
-    }
-  ],
-  "required_fixes": [
-    "Add validation for empty email in src/validators/user.ts:23",
-    "Add test case for invalid email format in tests/validators/user.test.ts",
-    "Handle null input in validateEmail() function"
-  ]
-}
-```
-
-### Validation Error: VALIDATION_ERROR
-
-Return this if input validation fails:
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["signal", "error_type", "errors"],
-  "properties": {
-    "signal": { "const": "VALIDATION_ERROR" },
-    "error_type": { "enum": ["invalid_input", "semantic_error"] },
-    "errors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["path", "message"],
-        "properties": {
-          "path": { "type": "string", "description": "JSON path to invalid field" },
-          "message": { "type": "string" },
-          "expected": { "type": "string" },
-          "received": { "type": "string" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "signal": "VALIDATION_ERROR",
-  "error_type": "invalid_input",
-  "errors": [
-    {
-      "path": "$.implementation.commit_hash",
-      "message": "Commit does not exist in git history",
-      "expected": "valid commit hash",
-      "received": "xyz9999"
-    }
-  ]
-}
-```
-
-## Re-Review Process (Retries)
-
-When `previous_rejections` is non-empty, this is a re-review after the implementer attempted fixes. Follow this modified process:
-
-### 1. Verify Previous Issues First
-
-Before running the full review checklist, check each issue from the most recent rejection:
-
-- **For each `required_fixes` item:** Verify the fix was applied. Check the specific file and line referenced.
-- **If a previous issue persists:** Re-raise it with the same severity. Note it is a **recurring issue** in the description — this signals the team-lead to consider model escalation.
-- **If a previous issue is fixed:** Do not re-raise it. Move on.
-
-### 2. Then Run Full Checklist
-
-After verifying previous fixes, run the standard review checklist. New issues can emerge from the fix attempt (regressions).
-
-### 3. Approval on Re-Review
-
-Only approve if:
-- **All** previously raised issues are resolved
-- **No new issues** of high or medium severity introduced
-- Standard review checklist still passes
-
-### 4. Example Re-Review Input
-
-```json
-{
-  "task": { "id": "002", "title": "Auth service", "acceptance_criteria": [...] },
-  "implementation": { "commit_hash": "def5678", "files_changed": [...], "test_file": "..." },
-  "spec_paths": { "technical_design": "...", "adr": "..." },
-  "previous_rejections": [
-    {
-      "attempt": 1,
-      "issues": [
-        { "criterion": "AC-002", "description": "Empty input not validated", "severity": "high" }
-      ],
-      "required_fixes": ["Add validation for empty email in src/validators/user.ts:23"]
-    }
-  ],
-  "worktree_path": "/path/to/worktree"
-}
-```
-
-In this case, first verify that `src/validators/user.ts:23` now validates empty email, then proceed with the full checklist.
+When `previous_rejections` non-empty: verify each prior issue first (check specific file:line). Persists → re-raise as "recurring issue" (signals escalation). Fixed → move on. Then run full checklist. Approve only if all prior issues resolved AND no new high/medium issues.
 
 ---
 
 ## Review Principles
 
-### Be Specific
+Be specific (cite file:line + AC). Reference specs (quote expected vs actual). Actionable feedback (specific fix, not "needs more X").
 
-**Bad:** "Tests are insufficient"
+## Red Flags — Immediate REJECT
 
-**Good:** "The `validateInput()` function lacks a test for empty string input, which is listed in acceptance criterion 3"
+Missing test for AC. Test passes without implementation. Diverges from TECHNICAL_DESIGN. Violates ADR security decisions.
 
-### Reference Specs
-
-**Bad:** "This doesn't look right"
-
-**Good:** "The technical design spec (`spec_paths.technical_design`) specifies the response format as `{data: [], meta: {}}` but implementation returns `{items: [], pagination: {}}`"
-
-### Actionable Feedback
-
-**Bad:** "Needs more error handling"
-
-**Good:** "Add try/catch in `processPayment()` at line 45 to handle the `PaymentGatewayError` case defined in the ADR section 4.2"
-
-## Red Flags - REJECT
-
-Immediately reject if any of these are present:
-
-- **Missing test**: An acceptance criterion has no corresponding test
-- **Test passes without implementation**: Test would pass even if the feature code were deleted
-- **Diverges from design**: Implementation contradicts the technical design spec (`spec_paths.technical_design`) without documented reason
-- **Security concern**: Implementation violates security decisions in the ADR (`spec_paths.adr`)
-
-### Handling Tautological Test Blockers
-
-When an implementer emits `IMPLEMENTATION_BLOCKED` with `blocker_type: "tautological_test"`:
-
-1. **Do NOT re-dispatch with the same test** — the test itself is the problem
-2. **Re-dispatch guidance for implementer:**
-   - "Strengthen test assertions to verify actual behavior, not just function existence"
-   - "Tests must fail when the critical implementation line is removed"
-   - "Focus on asserting return values, side effects, or state changes — not just that the function was called"
-3. **Include in feedback:** The specific file and line that was mutated, so the implementer knows which assertion to strengthen
-4. **Max retries:** If tautological test persists after 2 re-dispatch attempts, escalate to user
+**Tautological test blocker:** Don't re-dispatch same test. Guide: "strengthen assertions to verify actual behavior." Include mutated file:line. Max 2 retries → escalate.
 
 ## Exit Criteria
 
-Before completing your review, verify:
-
-- [ ] Every acceptance criterion has been checked against implementation and tests
-- [ ] Implementer's verification level checked (L3-only without justification flagged as finding)
-- [ ] You have provided either APPROVED or REJECTED status
-- [ ] If REJECTED, every issue has a specific file/line reference and required fix
-- [ ] If APPROVED, every criterion is listed with its implementation and test locations
+- [ ] All ACs checked; verification level validated; APPROVED or REJECTED emitted
+- [ ] REJECTED: every issue has file:line + required fix. APPROVED: every AC has impl + test locations

--- a/skills/scope-analysis/SKILL.md
+++ b/skills/scope-analysis/SKILL.md
@@ -224,7 +224,7 @@ Per component: interface_locations (file:section), pattern_files (discover via g
 ### 6. Extract Non-Scope & Change Impact Map
 From TECHNICAL_DESIGN: non-scope/exclusions section + impact/affected sections. Extract traceability from state.json.
 
-### 8. Write scope-analysis.json
+### 7. Write scope-analysis.json
 
 Assemble all extracted data into `docs/scope-analysis.json`:
 

--- a/skills/scope-analysis/SKILL.md
+++ b/skills/scope-analysis/SKILL.md
@@ -7,17 +7,13 @@ color: cyan
 
 # Scope Analysis Skill
 
-## Reference Materials
+## References
 
-- Model routing: `references/model-routing.json`
-- Signal contracts: `references/signal-contracts.json`
-- Agent handoff patterns: `references/context-engineering.md`
+`references/model-routing.json` · `references/signal-contracts.json` · `references/context-engineering.md`
 
 ## Overview
 
-Read specification documents and extract a structured scope analysis for the task-decomposer. This skill handles the mechanical work of spec reading: component extraction, AC validation, JIT context ref creation, and dependency mapping. The output is a condensed `docs/scope-analysis.json` that the task-decomposer uses as its primary input.
-
-**Model Selection:** This skill runs on **sonnet** because the work is mechanical — reading, extracting, and validating patterns. No judgment calls about decomposition or task sizing.
+Mechanical spec reading → structured scope analysis for task-decomposer. Extracts components, validates ACs, creates JIT context refs, maps dependencies. Output: `docs/scope-analysis.json`. **Model: sonnet** (mechanical extraction, no judgment).
 
 ---
 
@@ -215,117 +211,18 @@ Classify each component by layer:
 - `api` — Routes, endpoints, controllers
 - `ui` — Components, pages, layouts
 
-### 3. Validate Acceptance Criteria Testability
+### 3. Validate AC Testability
 
-For each acceptance criterion from the PRD, check testability patterns:
+Check each AC against EARS patterns: When/While/If/The system shall, quantitative thresholds, legacy Given/When/Then. Reject: adjective-only, vague outcomes, no thresholds, passive voice, missing "shall". Mark untestable ACs.
 
-#### EARS Format Recognition
+### 4. Generate Test Assertion Templates
+Map each valid AC → test assertion template (e.g., "API returns X" → `expect(response.body).toEqual(X)`).
 
-Acceptance criteria MUST use EARS (Easy Approach to Requirements Syntax). Validate against these patterns:
+### 5. Create JIT Context Refs
+Per component: interface_locations (file:section), pattern_files (discover via grep in src/), grep_patterns, constraints_section (ADR/TECHNICAL_DESIGN reference).
 
-| EARS Pattern | Regex | Example |
-|--------------|-------|---------|
-| Event-driven | `^When .+, the system shall` | "When user submits invalid email, the system shall display error" |
-| State-driven | `^While .+, the system shall` | "While unauthenticated, the system shall redirect to /login" |
-| Conditional | `^If .+, then the system shall` | "If token is expired, then the system shall return 401" |
-| Unconditional | `^The system shall` | "The system shall hash passwords using bcrypt" |
-| Quantitative | `shall .+ (within\|under\|less than\|<) [0-9]` | "The API shall respond within 200ms at p95" |
-| Legacy behavioral | `(Given\|When\|Then)` | "Given a user, when they log in, then session is created" |
-
-**Note:** Legacy Given/When/Then is accepted but EARS is preferred for new criteria.
-
-#### Invalid Patterns to Reject
-
-| Pattern | Example | Problem |
-|---------|---------|---------|
-| Adjective-only | "should be user-friendly" | No observable outcome |
-| Vague outcome | "should work correctly" | "correctly" is undefined |
-| No threshold | "must be fast" | No measurable target |
-| Passive/vague | "errors are handled" | What handling? |
-| Missing "shall" | "the system returns 200" | No obligation keyword — ambiguous intent |
-
-#### Validation Process
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Extract all acceptance criteria from PRD
-CRITERIA_FILE=$(mktemp)
-grep -E "^\s*-\s*\[" "$PRD_PATH" > "$CRITERIA_FILE"
-
-# Check each criterion for testable patterns
-while read -r line; do
-  criterion=$(echo "$line" | sed 's/^[^]]*\] *//')
-
-  if echo "$criterion" | grep -qE "(Given|When|Then)"; then
-    pattern="behavioral"
-  elif echo "$criterion" | grep -qE "(should|must|can|will) [a-z]+ [a-z]+"; then
-    pattern="assertion"
-  elif echo "$criterion" | grep -qE "[<>=≤≥] ?[0-9]"; then
-    pattern="quantitative"
-  else
-    echo "UNTESTABLE: $criterion"
-    pattern="invalid"
-  fi
-done < "$CRITERIA_FILE"
-rm -f "$CRITERIA_FILE"
-```
-
-### 4. Transform ACs to Test Assertion Templates
-
-For each valid criterion, generate a corresponding test assertion template:
-
-| Criterion Pattern | Test Assertion Template |
-|-------------------|------------------------|
-| "User must see X" | `expect(screen.getByText('X')).toBeVisible()` |
-| "API returns X" | `expect(response.body).toEqual(X)` |
-| "X < N" | `expect(X).toBeLessThan(N)` |
-| "Given A, when B, then C" | `describe('given A', () => { it('when B, should C', ...) })` |
-
-### 5. Create JIT Context References
-
-For each component identified in Step 2, create JIT context references:
-
-| Field | What to Provide | Example |
-|-------|----------------|---------|
-| `interface_locations` | File paths + section names for relevant types/interfaces | `["src/models/user.ts:User interface", "TECHNICAL_DESIGN.md:## Data Model"]` |
-| `pattern_files` | Paths to existing implementations showing the pattern to follow | `["src/services/base.ts"]` |
-| `grep_patterns` | Grep patterns to discover related code at runtime | `["export class.*Service", "interface Auth"]` |
-| `constraints_section` | Section reference in ADR/TECHNICAL_DESIGN for constraints | `"ADR.md:## Decision 1"` |
-
-Discover pattern files and interfaces from the codebase:
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Find existing service patterns
-find src/ -name "*.ts" -o -name "*.js" | head -20
-
-# Find existing model patterns
-grep -rn "export class\|export interface\|export type" src/ --include="*.ts" | head -20
-
-# Find existing test patterns
-ls tests/ 2>/dev/null || ls __tests__/ 2>/dev/null || echo "No test directory found"
-```
-
-### 6. Extract Non-Scope and Change Impact Map
-
-From TECHNICAL_DESIGN.md:
-
-```bash
-# Extract non-scope section
-grep -A 20 "## Non.Scope\|## Out of Scope\|## Exclusions" "$TECH_DESIGN_PATH"
-
-# Extract change impact
-grep -A 20 "## Impact\|## Affected" "$TECH_DESIGN_PATH"
-```
-
-### 7. Extract Traceability from State
-
-```bash
-# Extract traceability links from state.json
-jq '.traceability // {}' state.json
-```
+### 6. Extract Non-Scope & Change Impact Map
+From TECHNICAL_DESIGN: non-scope/exclusions section + impact/affected sections. Extract traceability from state.json.
 
 ### 8. Write scope-analysis.json
 
@@ -394,14 +291,6 @@ Return the `SCOPE_ANALYSIS_COMPLETE` signal:
 
 ## Exit Criteria
 
-- [ ] All spec documents read and analyzed
-- [ ] Components extracted with layer classification
-- [ ] Data models, API contracts, and dependencies extracted
-- [ ] All acceptance criteria validated for testability
-- [ ] Test assertion templates generated for valid criteria
-- [ ] JIT context refs created per component (interface locations, pattern files, grep patterns)
-- [ ] Non-scope boundaries and change impact map extracted
-- [ ] Traceability links preserved from state.json
-- [ ] `docs/scope-analysis.json` written and committed
-- [ ] `state.json` phase updated to `"task_decomposition"`
-- [ ] `SCOPE_ANALYSIS_COMPLETE` signal emitted
+- [ ] Specs read; components/models/contracts/deps extracted; ACs validated with test templates
+- [ ] JIT context refs created; non-scope + impact map extracted; traceability preserved
+- [ ] `docs/scope-analysis.json` committed; phase → `task_decomposition`; signal emitted

--- a/skills/scope-analysis/SKILL.md
+++ b/skills/scope-analysis/SKILL.md
@@ -249,7 +249,7 @@ cat > docs/scope-analysis.json << 'SCOPE_EOF'
 SCOPE_EOF
 ```
 
-### 9. Update State and Commit
+### 8. Update State and Commit
 
 ```bash
 cd "$WORKTREE_PATH"
@@ -265,7 +265,7 @@ Components: N, Acceptance Criteria: N
 All criteria testable: yes/no"
 ```
 
-### 10. Emit Signal
+### 9. Emit Signal
 
 Return the `SCOPE_ANALYSIS_COMPLETE` signal:
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -7,22 +7,13 @@ color: orange
 
 # Spec Review Skill
 
-## Reference Materials
+## References
 
-- Signal contracts: `references/signal-contracts.json`
-- Context patterns: `references/context-engineering.md`
-- Testability patterns: `references/discovery-questions.md`
-- Scale determination & doc segregation: `references/scale-determination.md`
+`references/signal-contracts.json` · `references/context-engineering.md` · `references/discovery-questions.md` · `references/scale-determination.md`
 
 ## Overview
 
-You are a **specification reviewer agent**. Your job: validate that discovery output (PRD, ADR, TECHNICAL_DESIGN) is internally consistent, complete, and ready for planning decomposition. This phase catches ambiguities and contradictions before they cascade into bad tasks.
-
-This skill runs between discovery and planning. It is a quality gate — specs that fail review go back to the user for correction before planning begins.
-
-**Model Selection:** Sonnet — review requires judgment but not deep architectural reasoning.
-
-**Context Budget:** Target < 15K tokens.
+Validate discovery output (PRD, ADR, TECHNICAL_DESIGN) for consistency, completeness, and testability. Quality gate between discovery and planning. **Model: sonnet. Budget: < 15K tokens.**
 
 ---
 
@@ -74,161 +65,24 @@ This skill runs between discovery and planning. It is a quality gate — specs t
 
 ## Process
 
-### 1. Cross-Document Consistency Check
-
-Verify that all documents agree on fundamental facts:
-
-**Data Model Alignment:**
-```bash
-# Extract data models mentioned in TECHNICAL_DESIGN
-grep -E "^#{1,3}.*[Mm]odel|^#{1,3}.*[Ss]chema|^#{1,3}.*[Ee]ntity" "$SPEC_PATH/TECHNICAL_DESIGN.md"
-
-# Cross-reference with PRD user stories
-grep -E "User|Account|Session|Token" "$SPEC_PATH/PRD.md"
-
-# Check ADR decisions reference same entities
-grep -E "User|Account|Session|Token" "$SPEC_PATH/ADR.md"
-```
-
-**Check for contradictions:**
-
-| Check | How | Severity |
-|-------|-----|----------|
-| PRD mentions entity not in TECHNICAL_DESIGN | Grep entity names across docs | High |
-| ADR decision contradicts TECHNICAL_DESIGN approach | Compare decision vs architecture section | High |
-| PRD acceptance criteria reference undefined API | Grep endpoints in PRD vs API Contracts | Medium |
-| Non-goals in PRD but implemented in TECHNICAL_DESIGN | Compare non-goals list vs components | Medium |
-| PRD success metrics unmeasurable with TECHNICAL_DESIGN | Check if metrics have data sources | Low |
+### 1. Cross-Document Consistency
+Grep entity names across docs. Check: PRD entity not in TECHNICAL_DESIGN (high), ADR contradicts TECHNICAL_DESIGN (high), PRD references undefined API (medium), non-goals implemented (medium), unmeasurable metrics (low).
 
 ### 2. Completeness Check
-
-Verify each document has required sections with substantive content:
-
-**PRD Completeness:**
-- [ ] Problem statement present and specific (not generic)
-- [ ] At least 1 goal with measurable outcome
-- [ ] At least 1 non-goal explicitly stated
-- [ ] At least 1 user story with acceptance criteria
-- [ ] Every acceptance criterion is testable (behavioral, assertion, or quantitative)
-
-**ADR Completeness:**
-- [ ] Context explains decision drivers
-- [ ] At least 2 options considered
-- [ ] Decision stated with rationale
-- [ ] Consequences listed (positive and negative)
-
-**TECHNICAL_DESIGN Completeness:**
-- [ ] Architecture overview present
-- [ ] Data models defined with field types
-- [ ] API contracts defined (if applicable)
-- [ ] Dependencies listed
-- [ ] Security considerations addressed
-- [ ] Testing strategy outlined
+**PRD:** problem statement, 1+ goals, 1+ non-goals, user stories with testable ACs. **ADR:** context/drivers, 2+ options, decision+rationale, consequences. **TECHNICAL_DESIGN:** architecture, data models, API contracts, deps, security, testing strategy.
 
 ### 3. Testability Audit
+Every PRD AC must match behavioral (Given/When/Then), assertion, or quantitative patterns. Flag untestable ACs.
 
-Every acceptance criterion from PRD must be testable:
+### 4. Design Sync
+Flag explicit conflicts: type mismatches, numeric disagreements, integration point mismatches, missing entities. Only explicit conflicts — omissions handled in step 2.
 
-```bash
-# Extract all acceptance criteria
-grep -E "^\s*-\s*\[" "$SPEC_PATH/PRD.md" | while read -r line; do
-  criterion=$(echo "$line" | sed 's/^[^]]*\] *//')
-
-  # Check for valid patterns
-  if echo "$criterion" | grep -qE "(Given|When|Then)"; then
-    echo "PASS (behavioral): $criterion"
-  elif echo "$criterion" | grep -qE "(should|must|can|will) [a-z]+ [a-z]+"; then
-    echo "PASS (assertion): $criterion"
-  elif echo "$criterion" | grep -qE "[<>=] ?[0-9]"; then
-    echo "PASS (quantitative): $criterion"
-  else
-    echo "FAIL (untestable): $criterion"
-  fi
-done
-```
-
-### 4. Design Sync (Cross-Document Consistency)
-
-Check for explicit conflicts between documents:
-
-| Conflict Type | Detection | Example |
-|---------------|-----------|---------|
-| Type mismatch | Same field has different types across docs | PRD says "email (string)" but TECHNICAL_DESIGN has "email (Email type)" |
-| Numeric parameter disagreement | Different values for same parameter | PRD says "8 char minimum" but ADR says "12 char minimum" |
-| Integration point mismatch | Described differently in different docs | PRD says REST API but TECHNICAL_DESIGN shows GraphQL |
-| Missing entity | Referenced in one doc but absent from another | PRD mentions "audit log" but no data model exists |
-
-**Only flag explicit conflicts.** Omissions are checked in completeness (step 2), not here.
-
-### 4.5. Template Version Check (Informational)
-
-Check if spec documents include `template_version` front-matter. This is a non-blocking informational check — missing version metadata does not affect the review verdict.
-
-```bash
-for doc in "$SPEC_PATH/PRD.md" "$SPEC_PATH/ADR.md" "$SPEC_PATH/TECHNICAL_DESIGN.md"; do
-  if [ -f "$doc" ]; then
-    VERSION=$(head -10 "$doc" | grep "template_version:" | awk '{print $2}' | tr -d '"')
-    if [ -z "$VERSION" ]; then
-      echo "INFO: $(basename $doc) missing template_version front-matter"
-    else
-      echo "OK: $(basename $doc) template_version=$VERSION"
-    fi
-  fi
-done
-```
-
-If any document is missing `template_version`, include an informational note (severity: `low`, category: `style`) in the review report. This helps track template drift but should never block planning.
-
-### 4.6. Scope Cohesion Check
-
-Assess whether the spec covers a cohesive, shippable unit or spans too many independent concerns. This check is advisory — it does **not** block approval.
-
-| Signal | Threshold | Severity |
-|--------|-----------|----------|
-| Component count | >8 | Medium — warn "Consider phasing" |
-| Distinct user types | >3 | Medium — warn "Multiple user types — should they ship together?" |
-| Non-scope items | >5 | Low — info "Large deferred scope. Phase 2 planning recommended" |
-
-**How to detect:**
-- Count top-level components or modules in TECHNICAL_DESIGN architecture section
-- Count distinct user/actor types across PRD user stories
-- Count items in the non-scope / non-goals lists across PRD and TECHNICAL_DESIGN
-
-Include any triggered warnings in the review report under the appropriate severity. These warnings use category `scope_cohesion`.
+### 4.5-4.6. Template Version & Scope Cohesion (Advisory)
+Template version: informational only (low/style). Scope cohesion: components >8 (medium), user types >3 (medium), non-scope >5 (low). Advisory — does not block approval. Category: `scope_cohesion`.
 
 ### 5. Generate Review Report
 
-Produce a structured review with severity levels:
-
-```markdown
-## Spec Review Report
-
-### Summary
-- Documents reviewed: PRD, ADR, TECHNICAL_DESIGN
-- Issues found: N high, M medium, P low
-- Verdict: APPROVED / NEEDS_REVISION
-
-### High Severity Issues
-> Must fix before planning
-
-1. **[CONTRADICTION]** PRD AC-003 requires "password >= 12 chars" but ADR-001 specifies bcrypt with 8 char minimum
-   - Files: PRD.md:45, ADR.md:23
-   - Fix: Align on single password length requirement
-
-### Medium Severity Issues
-> Should fix, may cause implementation confusion
-
-1. **[INCOMPLETE]** TECHNICAL_DESIGN missing error handling section for /register endpoint
-   - File: TECHNICAL_DESIGN.md
-   - Fix: Add error responses table
-
-### Low Severity Issues
-> Optional improvements
-
-1. **[STYLE]** PRD success metric "fast response" has no threshold
-   - File: PRD.md:12
-   - Fix: Add specific threshold (e.g., "< 200ms")
-```
+Structured report: summary (docs reviewed, issue counts, verdict) → high severity (must fix) → medium (should fix) → low (optional). Each issue: category, description, file:line, fix.
 
 ---
 
@@ -344,21 +198,7 @@ When verdict is `approved` with medium/low issues:
 
 ## Exit Criteria
 
-- [ ] All three documents read and analyzed
-- [ ] Cross-document consistency checked
-- [ ] Completeness verified for each document
-- [ ] Testability audit completed for all acceptance criteria
-- [ ] Review report generated with severity classification
-- [ ] Verdict determined (approved / needs_revision)
-- [ ] Signal emitted with structured JSON output
+- [ ] All docs analyzed; consistency, completeness, testability checked; verdict determined; signal emitted
 
----
-
-## Context Budget
-
-| Component | Budget | Strategy |
-|-----------|--------|----------|
-| Spec documents | ~6K | Read sections, not line-by-line |
-| Analysis | ~4K | Structured checks |
-| Report generation | ~2K | Template-based output |
-| **Buffer** | ~3K | Edge cases |
+## Context Budget: ~15K
+Spec docs ~6K | Analysis ~4K | Report ~2K | Buffer ~3K

--- a/skills/task-decomposition/SKILL.md
+++ b/skills/task-decomposition/SKILL.md
@@ -7,23 +7,15 @@ color: purple
 
 # Task Decomposition Skill
 
-## Reference Materials
+## References
 
-- Model routing: `references/model-routing.json`
-- Decomposition examples: `cookbooks/task-decomposition-examples.md`
-- Agent handoff patterns: `references/context-engineering.md`
+`references/model-routing.json` · `cookbooks/task-decomposition-examples.md` · `references/context-engineering.md`
 
 ## Overview
 
-Decompose a pre-analyzed scope into a sequence of test-bounded tasks. Each task represents exactly one commit with at least one verifying test (unless explicitly exempted). This skill receives `docs/scope-analysis.json` (produced by the scope-analyzer) as its primary input and transforms it into executable implementation units.
+Decompose pre-analyzed scope → test-bounded tasks. Each task = one commit + verifying test(s). Input: `docs/scope-analysis.json` from scope-analyzer. Output: executable implementation units in `docs/tasks.json`.
 
-**Model Selection:** This skill runs on **opus** because decomposition is high-leverage work — poor task boundaries cascade into implementation failures. See `references/context-engineering.md` for rationale.
-
-**What this skill does NOT do** (handled by scope-analysis):
-- Read raw spec documents (PRD, ADR, TECHNICAL_DESIGN)
-- Validate acceptance criteria testability
-- Extract components, data models, API contracts
-- Create JIT context references from scratch
+**Model: opus** — decomposition is high-leverage; poor boundaries cascade into implementation failures. Does NOT read raw specs, validate ACs, or extract components (scope-analysis handles those).
 
 ---
 
@@ -146,232 +138,41 @@ When task decomposition completes, output a JSON signal:
 
 ## Task Decomposition Rules
 
-### Each Task Must Be:
+### Task Requirements
 
-1. **Completable in a single commit** - No partial implementations
-2. **Test-bounded** - At least one test verifies the task is done
-3. **Clearly scoped** - Acceptance criteria derived from scope analysis
-4. **Dependency-aware** - Explicitly declares what it depends on
+Each task: single commit, test-bounded, clearly scoped (ACs from scope analysis), dependency-aware.
 
-### Task Sizing Guide
+**Sizing:** Too big (multiple stories, 4+ files, multi-concern ACs) → split. Right size (single change, one AC, testable alone). Too small (single constant, no testable behavior) → combine with consumer.
 
-**Too Big (split it):**
-- Implements multiple user stories
-- Touches more than 3-4 files substantially
-- Would take more than ~1 hour to implement
-- Has acceptance criteria spanning multiple concerns
-- Example: "Implement user authentication" (split into: schema, model, routes, middleware, tests)
+**No-test exceptions:** docs-only, config files, type definitions, dependency updates, dead code removal. Set `test_file: null` + `no_test_reason`.
 
-**Right Size:**
-- Single focused change
-- One clear acceptance criterion
-- Testable in isolation
-- 15-45 minutes of implementation
-- Example: "Add User model with password hashing"
+### AC Risk-Level Classification
 
-**Too Small (combine it):**
-- Adds a single constant or type
-- Changes only whitespace or formatting
-- Cannot be meaningfully tested alone
-- Example: "Add USER_ROLES constant" (combine with model that uses it)
-
-### No-Test Exceptions
-
-The following task types may skip the test requirement:
-
-| Exception | Reason | Verification Alternative |
-|-----------|--------|-------------------------|
-| Documentation only | No code behavior to test | Manual review |
-| Configuration files | Static data, no logic | Schema validation |
-| Type definitions only | TypeScript/Flow types | Type checker passes |
-| Dependency updates | Third-party code | Existing tests pass |
-| Delete dead code | Removal only | Existing tests pass |
-
-When using an exception, the task must include:
-```yaml
-test_file: null
-no_test_reason: "documentation only"
-```
-
-### AC Risk-Level Classification (Test Worthiness)
-
-Not every acceptance criterion needs a dedicated test. Classify each AC by risk level to control test bloat:
-
-| Risk Level | When to Use | Test Requirement |
+| Risk Level | When | Test Requirement |
 |---|---|---|
-| `must_test` | Core behavior, security checks, data mutations, business logic | Dedicated test per AC |
-| `verify_only` | Secondary behavior, simple CRUD, happy-path only | Consolidate into integration test with related ACs |
-| `structural` | Type correctness, field existence, config presence | Covered by types/lint — no runtime test needed |
+| `must_test` (default) | Core behavior, security, data mutations, user input | Dedicated test per AC |
+| `verify_only` | Secondary behavior, simple CRUD, happy-path | Consolidate into integration test |
+| `structural` | Type/field existence, config presence | Types/lint only |
 
-**Classification rules:**
-1. Default to `must_test` if uncertain
-2. ACs involving user input validation, authentication, or data persistence → always `must_test`
-3. ACs that only assert a field exists or a type compiles → `structural`
-4. Same-layer subtasks with related ACs can share a test file (`verify_only`)
+Test budget: Small 2-4, Medium 4-8, Large 10-20. Same-layer subtasks share test files.
 
-**Test budget by scale:**
+### Placeholder Rejection (No Vague ACs)
 
-| Scale | Test Budget | Rationale |
-|-------|-------------|-----------|
-| Small | 2-4 tests | Minimal feature, focused coverage |
-| Medium | 4-8 tests | Standard feature, per-component coverage |
-| Large | 10-20 tests | Complex feature, per-AC coverage for `must_test` |
+Every AC must suggest a specific test assertion. Reject: TBD/TODO, "add appropriate error handling", "similar to Task N", vague objectives. Detection: if AC doesn't suggest a test check → placeholder. On detection → `VALIDATION_ERROR` with `semantic_error`. Do NOT output tasks.json with placeholders.
 
-**Test consolidation guidance:** Subtasks within the same architectural layer (e.g., two model fields, two config entries) should share a test file rather than each getting a dedicated one.
+### Task Type Classification
 
-Add `risk_level` to each AC in the tasks.json output:
-
-```json
-{
-  "acceptance_criteria": [
-    {
-      "id": "AC-001",
-      "criterion": "User can register with email/password",
-      "risk_level": "must_test",
-      "test_assertion": "expect(user).toBeDefined()"
-    },
-    {
-      "id": "AC-002",
-      "criterion": "User model has created_at field",
-      "risk_level": "structural"
-    }
-  ]
-}
-```
-
-### Placeholder Rejection (Iron Law: No Vague ACs)
-
-Every acceptance criterion written into tasks.json MUST be concrete and implementable without interpretation. If you catch yourself writing a placeholder, STOP and fix it before proceeding.
-
-**Reject any AC matching these patterns:**
-
-| Pattern | Example | Why It Fails |
-|---------|---------|--------------|
-| Deferred language | "TBD", "TODO", "implement later", "fill in details" | Not an AC — it's a reminder to write one |
-| Generic quality hand-waves | "Add appropriate error handling", "add validation", "handle edge cases" | Describes WHAT without HOW — the implementer cannot verify completion |
-| Cross-references without substance | "Similar to Task N", "same as above" | Must repeat the concrete details — the implementer reads one task at a time |
-| Vague objectives | "Make it work correctly", "ensure good performance" | Describes intent without observable, testable behavior |
-
-**Detection rule:** If an AC does not suggest a specific test assertion, it is a placeholder. Every AC must answer: "What exact check would a test run to verify this?"
-
-**When placeholder ACs are detected** — whether in scope-analysis.json input or in your own draft — emit `VALIDATION_ERROR` and halt:
-
-```json
-{
-  "signal": "VALIDATION_ERROR",
-  "error_type": "semantic_error",
-  "errors": [
-    {
-      "path": "$.acceptance_criteria[N]",
-      "message": "Placeholder AC detected — not implementable without interpretation",
-      "expected": "Concrete criterion with testable assertion (e.g., 'Returns 401 when token is expired')",
-      "received": "Add appropriate error handling"
-    }
-  ]
-}
-```
-
-**Do NOT proceed to tasks.json output with placeholder ACs.** Fix them first by deriving concrete criteria from the scope analysis, or escalate if the source specs lack sufficient detail.
-
-### Task Type Classification (Model Routing)
-
-See `references/model-routing.json` for the authoritative task type to model mapping.
-
-**Classification rules:**
-1. Default to `haiku` for mechanical, pattern-following tasks
-2. Use `sonnet` when task requires design decisions or security implications
-3. Use `opus` only for architectural tasks requiring broad context
-4. If `decomposable=true` in the routing config, break into haiku-sized subtasks
+See `references/model-routing.json`. Default haiku for mechanical tasks, sonnet for design/security decisions, opus for architectural. If `decomposable=true` → break into haiku-sized subtasks.
 
 ---
 
 ## Subtask Decomposition Rules
 
-### MUST Decompose (Required)
+**MUST decompose:** ACs > 3, files > 4, 2+ architectural layers, decomposable in model-routing.json, title contains "and".
+**SHOULD decompose:** Multiple test files, mixed methodologies, external deps, risk concentration.
+**MUST NOT decompose:** Already haiku-level, single AC, pure refactoring, docs-only.
 
-A task MUST be decomposed into subtasks if ANY of these conditions:
-
-| Condition | Threshold | Rationale |
-|-----------|-----------|-----------|
-| Acceptance criteria count | > 3 | Too many behaviors for single focus |
-| Estimated files changed | > 4 | Too much scope for single commit |
-| Multiple architectural layers | >= 2 layers | E.g., model + service + API |
-| Task type is decomposable | See model-routing.json | Sonnet tasks often need subtasks |
-| Title contains "and" | Connecting distinct ops | "Create user AND send email" |
-
-### SHOULD Decompose (Recommended)
-
-Consider decomposition if ANY of these:
-
-| Condition | Signal | Action |
-|-----------|--------|--------|
-| Multiple test files needed | Different test concerns | Split by test file |
-| Mixed methodologies | TDD + config changes | Separate TDD from direct |
-| External dependencies | API calls, DB setup | Isolate integration points |
-| Risk concentration | One task blocks many | Reduce blast radius |
-
-### MUST NOT Decompose
-
-Do NOT decompose if:
-- Task is already haiku-level (add_field, add_method, etc.)
-- Single acceptance criterion
-- Pure refactoring with no behavior change
-- Documentation-only changes
-
-### Decomposition Patterns
-
-**Pattern 1: Vertical Slice**
-```
-Parent: "Create user registration"
-  +-- 001a: Create User model with fields
-  +-- 001b: Add validation methods to User
-  +-- 001c: Create UserService.register()
-  +-- 001d: Add /register endpoint
-  +-- 001e: Add registration tests
-```
-
-**Pattern 2: By Acceptance Criterion**
-```
-Parent: "Implement password reset" (AC-001, AC-002, AC-003)
-  +-- 001a: AC-001 - Generate reset token
-  +-- 001b: AC-002 - Send reset email
-  +-- 001c: AC-003 - Validate and update password
-```
-
-**Pattern 3: By Layer**
-```
-Parent: "Add audit logging"
-  +-- 001a: Create AuditLog model
-  +-- 001b: Create AuditService
-  +-- 001c: Add middleware for auto-logging
-  +-- 001d: Add audit log endpoint
-```
-
-### Subtask Specifications
-
-When decomposing, each subtask MUST have:
-
-```json
-{
-  "id": "001a",
-  "parent_id": "001",
-  "title": "Create User model with fields",
-  "task_type": "add_field",
-  "model": "haiku",
-  "acceptance_criteria": [
-    { "id": "001a-AC1", "text": "User model exists with email, password_hash fields" }
-  ],
-  "test_file": "tests/models/user.test.ts",
-  "blocked_by": [],
-  "estimated_scope": "single_file"
-}
-```
-
-**Subtask constraints:**
-- Max 1 acceptance criterion per subtask (prefer)
-- Single file focus when possible
-- Haiku model unless requires judgment
-- Clear dependency chain (a -> b -> c)
+**Patterns:** Vertical slice (model→service→endpoint), by AC, by layer. Subtask IDs: parent + letter (001a, 001b). Each subtask: max 1 AC preferred, single file focus, haiku model unless judgment needed, clear dependency chain.
 
 ---
 
@@ -405,63 +206,11 @@ jq '{session_id, branch, spec_paths, traceability}' state.json
 
 ### 2. Create Dependency Graph
 
-Using components from scope-analysis.json, map out which components depend on others:
-
-```
-                    ┌─────────────┐
-                    │   Schema    │
-                    │  (001-xxx)  │
-                    └──────┬──────┘
-                           │
-              ┌────────────┼────────────┐
-              │            │            │
-              ▼            ▼            ▼
-        ┌──────────┐ ┌──────────┐ ┌──────────┐
-        │  Model   │ │  Model   │ │  Types   │
-        │ (002-xx) │ │ (003-xx) │ │ (004-xx) │
-        └────┬─────┘ └────┬─────┘ └────┬─────┘
-             │            │            │
-             └────────────┼────────────┘
-                          │
-                          ▼
-                   ┌────────────┐
-                   │  Service   │
-                   │  (005-xx)  │
-                   └──────┬─────┘
-                          │
-             ┌────────────┼────────────┐
-             │            │            │
-             ▼            ▼            ▼
-       ┌──────────┐ ┌──────────┐ ┌──────────┐
-       │  Route   │ │  Route   │ │Middleware│
-       │ (006-xx) │ │ (007-xx) │ │ (008-xx) │
-       └──────────┘ └──────────┘ └──────────┘
-```
-
-**Rules for ordering:**
-1. Foundation tasks first (schemas, types, configs)
-2. Data layer before business logic
-3. Business logic before API/UI
-4. Integration tests after unit tests
-5. Documentation last
+Order: foundation (schemas, types, configs) → data layer → business logic → API/UI → integration tests → docs. Map component dependencies from scope-analysis.json.
 
 ### 3. Populate Task Context Refs
 
-For each task, populate `context_refs` using pre-computed JIT references from `scope-analysis.json`:
-
-```bash
-# Read pre-computed JIT refs for a component
-jq '.jit_context_refs.by_component["UserService"]' docs/scope-analysis.json
-```
-
-Each task's `context_refs` should include:
-
-| Field | Source | Example |
-|-------|--------|---------|
-| `interface_locations` | `scope-analysis.json → jit_context_refs.by_component[X].interface_locations` | `["src/models/user.ts:User interface"]` |
-| `pattern_files` | `scope-analysis.json → jit_context_refs.by_component[X].pattern_files` | `["src/services/base.ts"]` |
-| `grep_patterns` | `scope-analysis.json → jit_context_refs.by_component[X].grep_patterns` | `["export class.*Service"]` |
-| `constraints_section` | `scope-analysis.json → jit_context_refs.by_component[X].constraints_section` | `"ADR.md:## Decision 1"` |
+For each task, copy JIT refs from `scope-analysis.json → jit_context_refs.by_component[X]`: interface_locations, pattern_files, grep_patterns, constraints_section.
 
 ### 4. Write tasks.json
 
@@ -607,164 +356,22 @@ docs/
 }
 ```
 
-#### Task Fields
+Required task fields: id (NNN or NNNx), title, objective, task_type, acceptance_criteria (with risk_level), status, depends_on, traces_to. Optional: methodology (tdd|direct), test_file, no_test_reason, technical_notes, context_refs, model (haiku|sonnet|opus), subtasks.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| id | string | Yes | Sequential ID: "001", "002", or subtask "001a", "001b" |
-| title | string | Yes | Brief, imperative task description |
-| objective | string | Yes | What this task accomplishes |
-| task_type | enum | Yes | Classification for model routing (see Task Type Classification) |
-| methodology | enum | No | `tdd` (default) or `direct` for config/docs only |
-| acceptance_criteria | array | Yes | List of criteria with test assertions |
-| test_file | string | Conditional | Path to test file, null if exception applies |
-| no_test_reason | string | Conditional | Required if test_file is null |
-| status | enum | Yes | pending, in_progress, completed, blocked, failed |
-| depends_on | array | Yes | Task IDs that must complete first |
-| traces_to | object | Yes | Links to user stories, acceptance criteria, ADR decisions |
-| technical_notes | string | No | Implementation hints from specs |
-| context_refs | object | No | JIT references populated from scope-analysis.json |
-| model | enum | No | Which model executes: opus, sonnet (default), haiku |
-| subtasks | array | No | Decomposed subtasks for Haiku execution |
-
-#### Model Selection Guidelines
-
-| Task Complexity | Model | Examples |
-|-----------------|-------|----------|
-| **Complex** | opus | Architecture decisions, complex algorithms, refactoring |
-| **Standard** | sonnet | Most implementation tasks (default) |
-| **Simple** | haiku | Single-file changes, straightforward CRUD, config updates |
-
-#### Subtask Decomposition for Haiku
-
-When a task is too complex for Haiku, decompose into subtasks:
-
-```json
-{
-  "id": "002",
-  "title": "Create User model with validation",
-  "model": "sonnet",
-  "status": "pending",
-  "subtasks": [
-    {
-      "id": "002a",
-      "title": "Create User class with fields",
-      "objective": "Define User class with id, email, password_hash fields",
-      "acceptance_criteria": [
-        {"id": "AC-003a", "criterion": "User class exists with required fields"}
-      ],
-      "test_file": "tests/models/user.test.ts",
-      "status": "pending",
-      "depends_on": ["001"],
-      "model": "haiku"
-    }
-  ]
-}
-```
-
-**Subtask Rules:**
-- Subtask IDs use parent ID + letter suffix: "002a", "002b"
-- Each subtask should be completable in ~5-10 minutes
-- Subtasks can depend on each other or parent's dependencies
-- Parent task completes when all subtasks complete
+Model: haiku for simple single-file tasks, sonnet for standard (default), opus for architectural. When too complex for haiku → decompose into subtasks (parent ID + letter: 002a, 002b).
 
 ---
 
 ### 5. Validate Traceability
 
-After creating tasks.json, verify coverage using traceability from scope-analysis.json:
+Every AC from scope-analysis.json must map to at least one task. Flag coverage gaps.
 
-```bash
-cd "$WORKTREE_PATH"
+### 6. Update State & Transition
 
-# Check every AC from scope-analysis maps to at least one task
-jq -r '.acceptance_criteria[].id' docs/scope-analysis.json | while read ac; do
-  if ! jq -e ".tasks[] | select(.traces_to.acceptance_criteria | contains([\"$ac\"]))" docs/tasks.json > /dev/null 2>&1; then
-    echo "COVERAGE_GAP: $ac has no implementing task"
-  fi
-done
-```
-
-### 6. Update State
-
-After creating tasks.json, update state.json:
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Update state.json phase to "implementing"
-jq '.phase = "implementing" | .tasks_file = "docs/tasks.json"' state.json > tmp.json && mv tmp.json state.json
-```
-
-### 7. Transition
-
-1. **Commit tasks and state together:**
-   ```bash
-   TASK_COUNT=$(jq '.tasks | length' docs/tasks.json)
-   SUBTASK_COUNT=$(jq '[.tasks[].subtasks // [] | length] | add' docs/tasks.json)
-
-   git add docs/tasks.json state.json
-   git commit -m "plan: create ${TASK_COUNT} tasks for implementation
-
-   Tasks: ${TASK_COUNT} (${SUBTASK_COUNT} subtasks)
-   Ready for implementation phase.
-
-   Task list:
-   $(jq -r '.tasks[] | "- \(.id): \(.title)"' docs/tasks.json)"
-   ```
-
-2. **Return signal — do NOT spawn the next phase:**
-
-   ```json
-   {
-     "signal": "PLANNING_COMPLETE",
-     "timestamp": "<ISO8601>",
-     "source": { "skill": "homerun:task-decomposition" },
-     "payload": {
-       "tasks_count": N,
-       "tasks_file": "docs/tasks.json",
-       "dependency_graph_valid": true,
-       "coverage": {
-         "user_stories": N,
-         "acceptance_criteria": N
-       }
-     },
-     "envelope_version": "1.0.0"
-   }
-   ```
-
-   **Do NOT spawn the next phase.** Return after emitting this signal.
-
----
-
-## Output Structure
-
-After task decomposition completes, the worktree should contain:
-
-```
-docs/
-├── scope-analysis.json   # Input (from scope-analyzer)
-├── specs/
-│   ├── PRD.md
-│   ├── ADR.md
-│   ├── TECHNICAL_DESIGN.md
-│   └── WIREFRAMES.md
-└── tasks.json            # Output (from task-decomposer)
-```
-
----
+Update `state.json` phase → "implementing", tasks_file → "docs/tasks.json". Commit tasks.json + state.json. Emit `PLANNING_COMPLETE` signal with tasks_count, tasks_file, dependency_graph_valid, coverage. **Do NOT spawn next phase.**
 
 ## Exit Criteria
 
-Before transitioning to implementation, verify all criteria are met:
-
-- [ ] `docs/scope-analysis.json` read and understood
-- [ ] Dependency graph created showing task relationships
-- [ ] Each task is single-commit sized
-- [ ] Each task has test file specified (or valid exception documented)
-- [ ] Acceptance criteria trace back to scope analysis
-- [ ] context_refs populated from scope-analysis.json JIT refs
-- [ ] tasks.json written with all required fields
-- [ ] state.json updated with phase: "implementing" and tasks_file
-- [ ] All files committed to the feature branch
-- [ ] PLANNING_COMPLETE signal emitted
+- [ ] Scope analysis read; dependency graph created; all tasks single-commit sized
+- [ ] Test files specified (or valid exceptions); ACs trace to scope analysis; context_refs populated
+- [ ] tasks.json + state.json committed; `PLANNING_COMPLETE` emitted

--- a/skills/team-lead/SKILL.md
+++ b/skills/team-lead/SKILL.md
@@ -9,11 +9,7 @@ color: cyan
 
 ## Overview
 
-You are orchestrating Phase 3 (Implementation). This skill runs **inline in the main session** — you dispatch implementers directly, track progress via native tasks, and run a quality gate at the end.
-
-**Why inline?** Claude naturally handles coordination (ordering, parallelism, failure recovery) better than a constrained subagent with monitoring loops. This skill provides structure, not algorithms.
-
-**Announce at start:** "Starting implementation — dispatching tasks from the DAG."
+Orchestrate Phase 3 (Implementation) **inline in main session**. Dispatch implementers, track via native tasks, run quality gate. Announce: "Starting implementation — dispatching tasks from the DAG."
 
 ---
 
@@ -61,40 +57,11 @@ Pass 2: For each task with depends_on:
 
 ### 2.5. Feedback Pattern Injection
 
-Before dispatching implementers, check for accumulated feedback patterns from prior rejections in this session.
+If `feedback_patterns.json` exists: inject `common_patterns` and `session_patterns` into implementer prompts. Absent/empty → skip.
 
-```bash
-FEEDBACK_FILE="$WORKTREE_PATH/feedback_patterns.json"
-if [ -f "$FEEDBACK_FILE" ] && [ -s "$FEEDBACK_FILE" ]; then
-  PATTERNS=$(jq -r '.common_patterns // [] | join(", ")' "$FEEDBACK_FILE")
-  REJECTION_COUNT=$(jq -r '.total_rejections // 0' "$FEEDBACK_FILE")
-  echo "Session has $REJECTION_COUNT prior rejections. Common patterns: $PATTERNS"
-fi
-```
+### Iteration Caps
 
-**When feedback_patterns.json exists and is non-empty:**
-- Read the `common_patterns` and `session_patterns` arrays
-- Include a `previous_rejections` block in each implementer's task prompt:
-  ```
-  **Previous rejection patterns in this session (apply proactively):**
-  ${session_patterns.map(p => `- Task ${p.task_id}: ${p.rejection_reasons.join(', ')}`).join('\n')}
-
-  Common issues to avoid: ${common_patterns.join(', ')}
-  ```
-- This enables implementers to learn from earlier rejections without re-experiencing them
-
-**When feedback_patterns.json does not exist or is empty:**
-- Proceed normally — no injection needed
-- This is the common case for the first task in a session
-
-### Iteration Cap
-
-To prevent unbounded retry loops:
-
-- **Per-task cap:** Max 3 failed review cycles per individual task. After 3 rejections, mark the task as `needs_user_input` in tasks.json and escalate. Log: "Iteration cap reached for task [ID]. Escalating to user."
-- **Session cap:** Max 5 total retries across all tasks in a session. After hitting the cap, pause the dispatch loop and present current status to the user before continuing.
-
-These caps supersede any per-section retry limits below. When either cap is hit, do not retry — escalate.
+Per-task: max 3 rejections → `needs_user_input`, escalate. Session: max 5 total retries → pause, present status. Caps supersede per-section limits.
 
 ### 3. Dispatch Loop
 
@@ -159,21 +126,7 @@ Task({
 
 ### Requirement Change Detection
 
-During the dispatch loop, watch for signals that requirements have shifted. If ANY of these are detected in user messages, **stop the dispatch loop** and return to discovery/re-scoping before continuing:
-
-| Signal | Example | Action |
-|--------|---------|--------|
-| **New features mentioned** | "Oh, we should also add email notifications" | Stop — new scope needs spec updates |
-| **Constraint additions** | "Actually, this needs to work offline too" | Stop — constraint changes ripple through design |
-| **Technical requirement changes** | "Let's use WebSockets instead of polling" | Stop — architecture decision needs ADR update |
-| **Scope expansion** | "Can we also handle the admin side?" | Stop — new user stories need PRD update |
-| **Behavioral pivots** | "Actually the error should retry, not fail" | Assess — minor AC update vs. architectural change |
-
-**When detected:**
-1. Pause all pending implementer dispatches (let active ones finish)
-2. Inform the user: "I noticed a potential requirement change: [specific signal]. This may affect the current implementation plan."
-3. Ask whether to: (a) update specs and re-plan affected tasks, (b) note it for a follow-up, or (c) ignore — it was just thinking out loud
-4. If (a): update spec documents, re-run scope analysis for affected tasks only, resume dispatch
+Watch for: new features, constraint additions, technical changes, scope expansion, behavioral pivots. On detection → pause pending dispatches, inform user, ask: (a) update specs + re-plan, (b) note for follow-up, (c) ignore.
 
 ### 3.5. Continuous Incremental Review
 
@@ -219,6 +172,7 @@ if (activeReviewers < 2) {
     ${canSkipHardGates
       ? 'Hard gates passed in implementer self-review. Skip Tier 1, go straight to Tier 2 soft review.'
       : 'Run Tier 1 hard gates first, then Tier 2 soft review.'}
+    Use git diff ${task.commit_hash}~1..${task.commit_hash} as primary review input (diff-based review). Only read full files when diff context is insufficient.
     Emit APPROVED or REJECTED signal.`
   });
 } else {


### PR DESCRIPTION
## Summary

- **Compress skill prompts ~75%** across all 8 core skill files (-2,524 lines), converting verbose prose to terse bullet points, removing redundant examples/schemas, and consolidating process descriptions
- **Add diff-based review** so reviewers use `git diff` as primary input instead of reading full files, with fallback to full reads only when context is insufficient (~50-70% reviewer token savings)
- **Conditional reference loading** for agents: remove unconditionally-loaded secondary skills (TDD, systematic-debugging) from agent `skills:` lists, replacing with on-demand Read instructions (~6K saved per haiku task, ~4.5K per diagnostician)

Net: **-2,573 lines, +318 lines** across 12 files.

### Token savings breakdown

| Optimization | Savings | Scope |
|---|---|---|
| Prompt compression | ~10-15K tokens across all skill prompts | Every agent invocation |
| Diff-based review | 50-70% of reviewer token consumption | Every review cycle |
| Conditional TDD loading | ~6K tokens | Every haiku implementer dispatch |
| Conditional debugging loading | ~4.5K tokens | Every diagnostician dispatch |
| Extracted pre-impl analysis | ~1.5K tokens | Every haiku implementer dispatch |

### Files changed

**Skill files compressed:** implement, review, discovery, team-lead, task-decomposition, scope-analysis, spec-review, quality-check

**New file:** `skills/implement/pre-implementation-analysis.md` — extracted Steps 0a-0d for on-demand loading by sonnet/opus tasks only

**Agent definitions updated:** implementer (removed TDD skill, added conditional loading), diagnostician (removed systematic-debugging skill), reviewer (added diff-based review)

### Related issues

Closes #19 (Conditional reference loading)

Remaining optimization issues created: #20-#28

## Test plan

- [ ] Verify haiku implementer tasks still work without TDD skill loaded (uses `direct` methodology)
- [ ] Verify sonnet implementer tasks load TDD skill on-demand and follow TDD cycle
- [ ] Verify reviewer uses `git diff` output before falling back to full file reads
- [ ] Verify diagnostician can still read systematic-debugging skill when needed
- [ ] Run existing evals to confirm no quality regression from prompt compression

https://claude.ai/code/session_01DgoSo7nVBpckYEXcCUmz77