### PR TITLE
feat: add tiered small-scale TECHNICAL_DESIGN template

### DIFF
--- a/references/scale-determination.md
+++ b/references/scale-determination.md
@@ -77,12 +77,13 @@ Generate an ADR **regardless of scale** if ANY of these apply:
 
 ### Small (1-2 files)
 
-**TECHNICAL_DESIGN only** (simplified):
+**TECHNICAL_DESIGN only** — use the dedicated small-scale template (`templates/TECHNICAL_DESIGN_small.md`):
 - What to change and where (file paths + line ranges)
 - Data model changes (if any)
+- API contracts (if any)
 - Test strategy (which tests to add/modify)
-- No architecture overview needed
-- No API contracts section needed
+- Change impact map
+- No architecture overview, dependencies, NFRs, migration/rollback, or observability sections
 
 Skip: PRD (change is obvious), ADR (no architectural decision), WIREFRAMES
 

--- a/references/scale-determination.md
+++ b/references/scale-determination.md
@@ -6,7 +6,7 @@ Determines which specification documents to generate based on estimated task sco
 
 | Scale | Estimated Files | Documents to Generate | Dialogue Turns | Planning | Execution Pipeline |
 |-------|----------------|----------------------|----------------|----------|--------------------|
-| **Small** | 1-2 files | TECHNICAL_DESIGN only (simplified) | 5-8 | Simplified task list (no DAG) | Single implementer, no Agent Teams, skip spec-review + scope-analysis |
+| **Small** | 1-2 files | TECHNICAL_DESIGN_small.md only | 5-8 | Simplified task list (no DAG) | Single implementer, no Agent Teams, skip spec-review + scope-analysis |
 | **Medium** | 3-5 files | PRD + TECHNICAL_DESIGN | 10-15 | Full task DAG | Standard pipeline, max 2 concurrent implementers |
 | **Large** | 6+ files | PRD + ADR + TECHNICAL_DESIGN + WIREFRAMES | 15-20 | Full task DAG | Full pipeline, up to 5 concurrent implementers |
 
@@ -83,6 +83,7 @@ Generate an ADR **regardless of scale** if ANY of these apply:
 - API contracts (if any)
 - Test strategy (which tests to add/modify)
 - Change impact map
+- Agreement checklist (scope, non-scope, constraints, testing)
 - No architecture overview, dependencies, NFRs, migration/rollback, or observability sections
 
 Skip: PRD (change is obvious), ADR (no architectural decision), WIREFRAMES

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -58,7 +58,7 @@ Acknowledge previous answers → build connections → summarize every 2-3 excha
 
 | Scale | Files | Documents | Dialogue |
 |-------|-------|-----------|----------|
-| **Small** (1-2) | TECHNICAL_DESIGN only | 5-8 turns |
+| **Small** (1-2) | TECHNICAL_DESIGN_small.md only | 5-8 turns |
 | **Medium** (3-5) | PRD + TECHNICAL_DESIGN | 10-15 turns |
 | **Large** (6+) | PRD + ADR + TECHNICAL_DESIGN + WIREFRAMES | 15-20 turns |
 
@@ -104,7 +104,7 @@ mkdir -p "${WORKTREE_PATH}/docs"
 Templates: `templates/*.md`. Generate only scale-appropriate documents.
 
 **Template selection by scale:**
-- **Small (1-2 files):** Use `templates/TECHNICAL_DESIGN_small.md` — focused template with: Overview, What to Change, Data Models, API Contracts, Testing Strategy, Change Impact Map.
+- **Small (1-2 files):** Use `templates/TECHNICAL_DESIGN_small.md` — focused template with: Overview, What to Change, Data Models, API Contracts, Testing Strategy, Change Impact Map, Agreement Checklist.
 - **Medium/Large (3+ files):** Use `templates/TECHNICAL_DESIGN.md` — full template with all sections.
 
 **Strict boundaries:** PRD = business value only | ADR = decision rationale only | TECHNICAL_DESIGN = implementation only | WIREFRAMES = UI only (skip for CLI/API/library). Cross-reference, don't duplicate.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -103,11 +103,15 @@ mkdir -p "${WORKTREE_PATH}/docs"
 
 Templates: `templates/*.md`. Generate only scale-appropriate documents.
 
+**Template selection by scale:**
+- **Small (1-2 files):** Use `templates/TECHNICAL_DESIGN_small.md` — focused template with: Overview, What to Change, Data Models, API Contracts, Testing Strategy, Change Impact Map.
+- **Medium/Large (3+ files):** Use `templates/TECHNICAL_DESIGN.md` — full template with all sections.
+
 **Strict boundaries:** PRD = business value only | ADR = decision rationale only | TECHNICAL_DESIGN = implementation only | WIREFRAMES = UI only (skip for CLI/API/library). Cross-reference, don't duplicate.
 
 **Requirements:** FRs in PRD (MoSCoW priority, EARS-format ACs). NFRs: quantified targets in PRD, implementation in TECHNICAL_DESIGN. Omit categories without measurable targets.
 
-**Quality:** Ground in codebase (real files/patterns). ACs must be testable. Non-scope explicit in TECHNICAL_DESIGN with Change Impact Map (direct/indirect/unaffected). Right-size detail — no boilerplate. Omit inapplicable sections entirely.
+**Quality:** Ground in codebase (real files/patterns). ACs must be testable. Non-scope explicit in TECHNICAL_DESIGN with Change Impact Map (direct/indirect/unaffected). Small features use `TECHNICAL_DESIGN_small.md`; large features get full document set. No boilerplate. Omit inapplicable sections entirely.
 
 Write documents to `$HOMERUN_DOCS_DIR/`.
 

--- a/templates/TECHNICAL_DESIGN_small.md
+++ b/templates/TECHNICAL_DESIGN_small.md
@@ -1,0 +1,97 @@
+---
+template_version: "1.1"
+template_name: "TECHNICAL_DESIGN_small"
+compatible_homerun: ">=5.0.0"
+---
+
+# Technical Design: {{FEATURE_NAME}}
+
+<!--
+SMALL-SCALE TEMPLATE (1-2 files)
+Focused subset of the full TECHNICAL_DESIGN template for small features.
+Omits: Architecture diagrams, Dependencies, NFRs, Migration/Rollback,
+       Observability, Error Handling (overkill at this scale).
+INCLUDES: Overview, what to change, data models, testing strategy,
+          change impact, agreement checklist
+EXCLUDES: Business motivation, user stories (-> PRD)
+          Decision rationale, option comparisons (-> ADR)
+-->
+
+## Overview
+
+{{1-2 sentence summary of what this change does}}
+
+## What to Change
+
+| File | Lines | Change Description |
+|------|-------|--------------------|
+| {{file path}} | {{line range}} | {{what to modify}} |
+
+### Patterns to Follow
+
+| Pattern | Source |
+|---------|--------|
+| {{Pattern name}} | {{file path}} |
+
+## Data Models
+
+_Skip this section if no data model changes._
+
+### {{Model Name}}
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| {{field}} | {{type}} | {{constraints}} | {{description}} |
+
+## API Contracts
+
+_Skip this section if no API changes._
+
+### {{Endpoint Name}}
+
+**Method:** `{{HTTP_METHOD}}`
+**Path:** `{{/api/path}}`
+
+**Request:**
+```json
+{
+  "{{field}}": "{{type}} - {{description}}"
+}
+```
+
+**Response (Success):**
+```json
+{
+  "{{field}}": "{{type}} - {{description}}"
+}
+```
+
+## Testing Strategy
+
+| Component | Test File | Coverage Focus |
+|-----------|-----------|----------------|
+| {{name}} | {{path}} | {{what to test}} |
+
+## Change Impact Map
+
+### Direct Impact (files being modified)
+
+| File/Module | Change Description |
+|-------------|-------------------|
+| {{path}} | {{what changes}} |
+
+### Indirect Impact (files that import/use changed code)
+
+| File/Module | Dependency | Verification |
+|-------------|-----------|--------------|
+| {{path}} | Imports {{symbol}} from {{changed file}} | {{How to verify no breakage}} |
+
+### No Ripple Effect (explicitly unaffected)
+
+- {{Feature/module confirmed unaffected and why}}
+
+## Agreement Checklist
+
+- [ ] **Scope**: {{What changes — list of files}}
+- [ ] **Non-scope**: {{What explicitly does NOT change}}
+- [ ] **Testing**: {{Test strategy — which tests to add/modify}}

--- a/templates/TECHNICAL_DESIGN_small.md
+++ b/templates/TECHNICAL_DESIGN_small.md
@@ -94,4 +94,9 @@ _Skip this section if no API changes._
 
 - [ ] **Scope**: {{What changes — list of files}}
 - [ ] **Non-scope**: {{What explicitly does NOT change}}
+- [ ] **Constraints**: {{Backward compatibility, performance requirements}}
 - [ ] **Testing**: {{Test strategy — which tests to add/modify}}
+
+## Open Questions
+
+- [ ] {{Question that needs resolution}}

--- a/templates/TECHNICAL_DESIGN_small.md
+++ b/templates/TECHNICAL_DESIGN_small.md
@@ -11,8 +11,8 @@ SMALL-SCALE TEMPLATE (1-2 files)
 Focused subset of the full TECHNICAL_DESIGN template for small features.
 Omits: Architecture diagrams, Dependencies, NFRs, Migration/Rollback,
        Observability, Error Handling (overkill at this scale).
-INCLUDES: Overview, what to change, data models, testing strategy,
-          change impact, agreement checklist
+INCLUDES: Overview, what to change, data models, API contracts,
+          testing strategy, change impact, agreement checklist
 EXCLUDES: Business motivation, user stories (-> PRD)
           Decision rationale, option comparisons (-> ADR)
 -->


### PR DESCRIPTION
## Summary

- Add `templates/TECHNICAL_DESIGN_small.md` — a focused template for small features (1-2 files) that includes only: Overview, What to Change, Data Models, API Contracts, Testing Strategy, and Change Impact Map
- Update `skills/discovery/SKILL.md` with template selection logic that routes small features to the compact template and medium/large to the full template
- Update `references/scale-determination.md` to reference the new small-scale template and clarify which sections are included/excluded

Estimated savings: ~500-1000 tokens per small feature in both generation and downstream consumption.

Closes #21

## Test plan

- [ ] Verify `TECHNICAL_DESIGN_small.md` has correct YAML front-matter (version 1.1, compatible_homerun >=5.0.0)
- [ ] Verify discovery skill references the small template for scale "small" and the full template for "medium"/"large"
- [ ] Verify `scale-determination.md` small-scale section aligns with the new template's sections
- [ ] Run a small-scale discovery flow and confirm the compact template is selected

https://claude.ai/code/session_0123PuGH5QFwHAYnPBwFco55