### PR TITLE
feat: skip LLM quality-check phases for haiku-tier tasks

### DIFF
--- a/references/model-routing.json
+++ b/references/model-routing.json
@@ -19,7 +19,12 @@
       "decomposable": false,
       "default_methodology": "direct",
       "methodology_note": "Simple tasks use direct+tests, not full TDD cycle",
-      "skip_step_0": true
+      "skip_step_0": true,
+      "quality_gate": {
+        "skip_structural_review": true,
+        "skip_llm_autofix": true,
+        "note": "Deterministic checks only (lint, types, tests). LLM phases have low signal-to-cost ratio for mechanical tasks."
+      }
     },
     "sonnet": {
       "task_types": [
@@ -56,7 +61,7 @@
     "test_skeletons": "sonnet",
     "team_lead": "sonnet",
     "reviewer": "sonnet",
-    "quality_check": "sonnet",
+    "quality_check": "sonnet (haiku-tier sessions: LLM phases skipped, no model cost)",
     "diagnose": "sonnet",
     "reverse_engineer": "opus",
     "walkthrough": "sonnet"

--- a/skills/quality-check/SKILL.md
+++ b/skills/quality-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-check
-description: "[sonnet] Multi-phase quality pipeline: lint, types, structure, tests, recheck"
+description: "[sonnet/haiku-tier] Multi-phase quality pipeline: lint, types, structure, tests, recheck. Haiku-tier tasks skip LLM phases."
 model: sonnet
 color: teal
 ---
@@ -19,9 +19,9 @@ You are a **quality assurance agent**. Your job: run a structured 5-phase qualit
 
 The team-lead can invoke this after review approval or as a standalone gate before completion.
 
-**Model Selection:** Sonnet — quality checks require judgment for fixes but not deep reasoning.
+**Model Selection:** Sonnet — quality checks require judgment for fixes but not deep reasoning. For `tier: "haiku"` sessions, LLM phases are skipped entirely.
 
-**Context Budget:** Target < 15K tokens.
+**Context Budget:** Target < 15K tokens (< 5K for haiku-tier).
 
 ---
 
@@ -44,6 +44,12 @@ The team-lead can invoke this after review approval or as a standalone gate befo
       "enum": ["auto", "report_only"],
       "default": "auto",
       "description": "auto: fix issues and recommit. report_only: report without changing files."
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["haiku", "sonnet", "opus"],
+      "default": "sonnet",
+      "description": "Execution tier of the tasks in this session. haiku: skip LLM phases (Phase 3 structural review, Phase 4 auto-fix). sonnet/opus: full pipeline."
     }
   }
 }
@@ -56,9 +62,27 @@ The team-lead can invoke this after review approval or as a standalone gate befo
   "worktree_path": "../myapp-create-user-auth-a1b2c3d4",
   "files_changed": ["src/services/auth.ts", "tests/services/auth.test.ts"],
   "task_id": "002",
-  "fix_mode": "auto"
+  "fix_mode": "auto",
+  "tier": "sonnet"
 }
 ```
+
+---
+
+## Tier Routing
+
+Before starting, determine which phases to run:
+
+```
+tier == "haiku"  → run Phase 1 (lint), Phase 2 (types), Phase 4 (tests, report_only), Phase 5 (recheck)
+                   SKIP Phase 3 (structural review — LLM)
+                   OVERRIDE fix_mode to "report_only" for Phase 4 (no LLM auto-fix)
+
+tier == "sonnet" → full pipeline (all 5 phases, fix_mode as specified)
+tier == "opus"   → full pipeline (all 5 phases, fix_mode as specified)
+```
+
+**Why skip for haiku?** Haiku-tier tasks (`add_field`, `add_method`, `add_validation`, etc.) are mechanical single-focus changes. The structural review phase adds LLM cost (~3K tokens) but provides minimal signal for tasks that don't involve new abstractions, dead code risks, or naming decisions. Deterministic checks (lint, types, tests) are sufficient.
 
 ---
 
@@ -104,7 +128,9 @@ TYPE_EXIT=$?
 
 The quality-checker agent does NOT run type checking — it reads the hook's exit code and reports the result.
 
-### Phase 3: Structural Review (LLM JUDGMENT — this is where you add value)
+### Phase 3: Structural Review (LLM JUDGMENT — skipped for haiku-tier)
+
+**Tier check:** If `tier == "haiku"`, skip this phase entirely. Emit `"status": "skipped", "reason": "haiku_tier"` in the phase result and proceed to Phase 4.
 
 This is the ONLY phase that requires LLM reasoning. The other phases are deterministic CLI checks.
 
@@ -145,7 +171,9 @@ Classify each structural finding as **blocking** or **advisory**:
 
 Advisory-only findings result in `pass` (not `fail`). Only blocking findings cause `fail`.
 
-### Phase 4: Tests (DETERMINISTIC — no LLM judgment)
+### Phase 4: Tests (DETERMINISTIC — haiku-tier uses report_only)
+
+**Tier check:** If `tier == "haiku"`, override `fix_mode` to `"report_only"` for this phase regardless of the input value. Do not attempt LLM auto-fix for haiku tasks — just run tests, report results, and proceed.
 
 ```bash
 cd "$WORKTREE_PATH"
@@ -239,7 +267,8 @@ If new issues introduced by auto-fixes, revert auto-fixes and report as `needs_m
       "properties": {
         "status": { "enum": ["pass", "fixed", "fail", "skipped"] },
         "issues_found": { "type": "integer" },
-        "issues_fixed": { "type": "integer" }
+        "issues_fixed": { "type": "integer" },
+        "reason": { "type": "string", "description": "Why this phase was skipped (e.g. 'haiku_tier', 'skipped_by_hooks')" }
       }
     }
   }

--- a/skills/team-lead/SKILL.md
+++ b/skills/team-lead/SKILL.md
@@ -274,17 +274,24 @@ while (pendingTasks > 0 || activeImplementers > 0 || activeReviewers > 0):
 After all tasks complete (or are skipped):
 
 ```javascript
+// Determine session tier: if ALL tasks were haiku-type, tier = "haiku". Otherwise "sonnet".
+const HAIKU_TYPES = ["add_field", "add_method", "add_validation", "rename_refactor", "add_test", "add_config", "add_endpoint"];
+const sessionTier = completedTasks.every(t => HAIKU_TYPES.includes(t.task_type)) ? "haiku" : "sonnet";
+
 Task({
   description: "Final quality check",
   subagent_type: "homerun:quality-checker",
-  prompt: `Run the 5-phase quality pipeline.
+  prompt: `Run the quality pipeline.
 
   Worktree: ${worktreePath}
   Files changed: ${allChangedFiles}
   Fix mode: auto
+  Tier: ${sessionTier}
 
-  Run lint, type checks, structural review, tests, and final recheck.
-  Auto-fix issues where possible.`
+  ${sessionTier === "haiku"
+    ? "Haiku-tier session: run lint, type checks, and tests only. Skip structural review (Phase 3) and LLM auto-fix."
+    : "Run lint, type checks, structural review, tests, and final recheck. Auto-fix issues where possible."
+  }`
 });
 ```
 


### PR DESCRIPTION
Closes #22

## Why

Haiku-tier tasks (`add_field`, `add_method`, `add_validation`, `rename_refactor`, `add_test`, `add_config`, `add_endpoint`) are mechanical, single-focus changes. The quality-check skill's two LLM phases add token cost with low signal:

- **Phase 3 (structural review):** ~3K tokens to check for unused imports and debug artifacts in a file that only adds one field
- **Phase 4 (auto-fix):** LLM repair attempts on test failures for tasks where the fix is obvious from the error

Deterministic checks (lint, types, tests, recheck) are sufficient for this tier.

This is the quality-gate counterpart to PR #29's conditional TDD removal for haiku implementers — completing the haiku-tier token optimization.

## What changed

**`skills/quality-check/SKILL.md`**
- Added `tier` input field (`"haiku" | "sonnet" | "opus"`, default `"sonnet"`)
- Added **Tier Routing** section at the top of Process documenting which phases run per tier
- Phase 3: guarded with tier check — skips with `"status": "skipped", "reason": "haiku_tier"` for haiku
- Phase 4: overrides `fix_mode` to `"report_only"` for haiku (no LLM auto-fix)
- Output schema: added `reason` field to `phase_result` definition

**`skills/team-lead/SKILL.md`**
- Quality Gate section: computes `sessionTier` from `completedTasks` using the canonical `HAIKU_TYPES` list
- Passes `tier` to the quality-checker invocation prompt

**`references/model-routing.json`**
- Added `quality_gate` config block to haiku routing (`skip_structural_review`, `skip_llm_autofix`)
- Clarified `quality_check` phase model entry to note haiku-tier behavior

## Token savings

~3K tokens saved per haiku-tier session (Phase 3 structural review) plus LLM auto-fix attempts avoided. Consistent with the effort-proportional model established in `model-routing.json`.

https://claude.ai/code/session_jarvis